### PR TITLE
refactor: add NetworkListViewModel following established pattern

### DIFF
--- a/internal/ui/keyhandler.go
+++ b/internal/ui/keyhandler.go
@@ -549,54 +549,27 @@ func (m *Model) ShowImageInspect(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 // Network list handlers
 func (m *Model) SelectUpNetwork(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if m.selectedDockerNetwork > 0 {
-		m.selectedDockerNetwork--
-	}
-	return m, nil
+	return m, m.networkListViewModel.HandleSelectUp()
 }
 
 func (m *Model) SelectDownNetwork(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if m.selectedDockerNetwork < len(m.dockerNetworks)-1 {
-		m.selectedDockerNetwork++
-	}
-	return m, nil
+	return m, m.networkListViewModel.HandleSelectDown()
 }
 
 func (m *Model) ShowNetworkList(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	m.currentView = NetworkListView
-	m.loading = true
-	return m, loadDockerNetworks(m.dockerClient)
+	return m, m.networkListViewModel.Show(m)
 }
 
 func (m *Model) DeleteNetwork(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if m.selectedDockerNetwork < len(m.dockerNetworks) {
-		network := m.dockerNetworks[m.selectedDockerNetwork]
-		// Don't allow removing default networks
-		if network.Name == "bridge" || network.Name == "host" || network.Name == "none" {
-			m.err = fmt.Errorf("cannot remove default network: %s", network.Name)
-			return m, nil
-		}
-		m.loading = true
-		return m, removeNetwork(m.dockerClient, network.ID)
-	}
-	return m, nil
+	return m, m.networkListViewModel.HandleDelete(m)
 }
 
 func (m *Model) ShowNetworkInspect(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if m.selectedDockerNetwork < len(m.dockerNetworks) {
-		network := m.dockerNetworks[m.selectedDockerNetwork]
-		m.inspectNetworkID = network.ID
-		m.inspectContainerID = "" // Clear container ID
-		m.inspectImageID = ""     // Clear image ID
-		m.loading = true
-		return m, loadNetworkInspect(m.dockerClient, network.ID)
-	}
-	return m, nil
+	return m, m.networkListViewModel.HandleInspect(m)
 }
 
 func (m *Model) BackFromNetworkList(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	m.currentView = ComposeProcessListView
-	return m, loadProcesses(m.dockerClient, m.projectName, m.composeProcessListViewModel.showAll)
+	return m, m.networkListViewModel.HandleBack(m)
 }
 
 func (m *Model) CmdFileBrowse(_ tea.KeyMsg) (tea.Model, tea.Cmd) {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -112,14 +112,12 @@ type Model struct {
 	imageListViewModel           ImageListViewModel
 	fileContentViewModel         FileContentViewModel
 	helpViewModel                HelpViewModel
+	networkListViewModel         NetworkListViewModel
 
 	// Docker images state
 	dockerImages        []models.DockerImage
 	selectedDockerImage int
 
-	// Docker networks state
-	dockerNetworks        []models.DockerNetwork
-	selectedDockerNetwork int
 
 	// Docker volumes state
 	dockerVolumes        []models.DockerVolume

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -133,7 +133,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case DockerContainerListView:
 			return m, loadDockerContainers(m.dockerClient, m.dockerContainerListViewModel.showAll)
 		case NetworkListView:
-			return m, loadDockerNetworks(m.dockerClient)
+			return m, m.networkListViewModel.HandleRefresh(m)
 		default:
 			return m, loadProcesses(m.dockerClient, m.projectName, m.dockerContainerListViewModel.showAll)
 		}
@@ -200,11 +200,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.err = msg.err
 			return m, nil
 		}
-		m.dockerNetworks = msg.networks
+		m.networkListViewModel.Loaded(msg.networks)
 		m.err = nil
-		if len(m.dockerNetworks) > 0 && m.selectedDockerNetwork >= len(m.dockerNetworks) {
-			m.selectedDockerNetwork = 0
-		}
 		return m, nil
 
 	case dockerVolumesLoadedMsg:
@@ -301,7 +298,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case ImageListView:
 			return m, loadDockerImages(m.dockerClient, m.imageListViewModel.showAll)
 		case NetworkListView:
-			return m, loadDockerNetworks(m.dockerClient)
+			return m, m.networkListViewModel.HandleRefresh(m)
 		case VolumeListView:
 			return m, loadDockerVolumes(m.dockerClient)
 		case FileBrowserView:

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -298,7 +298,7 @@ func (m *Model) viewBody(availableHeight int) string {
 	case ImageListView:
 		return m.renderImageList(availableHeight)
 	case NetworkListView:
-		return m.renderNetworkList(availableHeight)
+		return m.networkListViewModel.render(m, availableHeight)
 	case VolumeListView:
 		return m.renderVolumeList()
 	case FileBrowserView:

--- a/internal/ui/view_network_test.go
+++ b/internal/ui/view_network_test.go
@@ -18,32 +18,34 @@ func TestNetworkListView(t *testing.T) {
 			name: "network list with multiple networks",
 			model: Model{
 				currentView: NetworkListView,
-				dockerNetworks: []models.DockerNetwork{
-					{
-						ID:       "58c772315063",
-						Name:     "blog4_default",
-						Driver:   "bridge",
-						Scope:    "local",
-						Internal: false,
+				networkListViewModel: NetworkListViewModel{
+					dockerNetworks: []models.DockerNetwork{
+						{
+							ID:       "58c772315063",
+							Name:     "blog4_default",
+							Driver:   "bridge",
+							Scope:    "local",
+							Internal: false,
+						},
+						{
+							ID:       "0e4dfb157d47",
+							Name:     "bridge",
+							Driver:   "bridge",
+							Scope:    "local",
+							Internal: false,
+						},
+						{
+							ID:       "c65e5d9416a7",
+							Name:     "dcv-development",
+							Driver:   "bridge",
+							Scope:    "local",
+							Internal: true,
+						},
 					},
-					{
-						ID:       "0e4dfb157d47",
-						Name:     "bridge",
-						Driver:   "bridge",
-						Scope:    "local",
-						Internal: false,
-					},
-					{
-						ID:       "c65e5d9416a7",
-						Name:     "dcv-development",
-						Driver:   "bridge",
-						Scope:    "local",
-						Internal: true,
-					},
+					selectedDockerNetwork: 1,
 				},
-				selectedDockerNetwork: 1,
-				width:                 120,
-				height:                30,
+				width:  120,
+				height: 30,
 			},
 			expected: []string{
 				"NETWORK ID",
@@ -60,10 +62,12 @@ func TestNetworkListView(t *testing.T) {
 		{
 			name: "empty network list",
 			model: Model{
-				currentView:    NetworkListView,
-				dockerNetworks: []models.DockerNetwork{},
-				width:          120,
-				height:         30,
+				currentView: NetworkListView,
+				networkListViewModel: NetworkListViewModel{
+					dockerNetworks: []models.DockerNetwork{},
+				},
+				width:  120,
+				height: 30,
 			},
 			expected: []string{
 				"No networks found",
@@ -88,7 +92,7 @@ func TestNetworkListView(t *testing.T) {
 }
 
 func TestRenderNetworkList(t *testing.T) {
-	m := &Model{
+	vm := &NetworkListViewModel{
 		dockerNetworks: []models.DockerNetwork{
 			{
 				ID:       "abc123",
@@ -101,8 +105,10 @@ func TestRenderNetworkList(t *testing.T) {
 		selectedDockerNetwork: 0,
 	}
 
+	m := &Model{}
+
 	// Test rendering with sufficient height
-	output := m.renderNetworkList(10)
+	output := vm.render(m, 10)
 
 	assert.Contains(t, output, "NETWORK ID")
 	assert.Contains(t, output, "NAME")


### PR DESCRIPTION
## Summary
- Refactored `view_network_list.go` to use the ViewModel pattern for better separation of concerns
- Created `NetworkListViewModel` struct to manage network list view state and rendering
- Updated all references throughout the codebase to use the new ViewModel

## Changes
- Added `NetworkListViewModel` struct with:
  - `dockerNetworks` and `selectedDockerNetwork` fields moved from Model
  - `render()` method for view rendering
  - `Show()`, `HandleSelectUp/Down()`, `HandleDelete()`, `HandleInspect()`, `HandleBack()`, `HandleRefresh()`, and `Loaded()` methods
- Removed `dockerNetworks` and `selectedDockerNetwork` from main `Model` struct
- Updated all keyhandlers to use ViewModel methods
- Updated `update.go` to use ViewModel for network loading and refresh
- Updated `view.go` to use ViewModel render method
- Updated tests to use the new ViewModel structure

## Test plan
- [x] Run existing tests to ensure no regressions
- [ ] Manually test network list functionality:
  - [ ] View network list with `n` key
  - [ ] Navigate up/down through networks
  - [ ] Inspect network details with `Enter`
  - [ ] Delete non-default networks with `D`
  - [ ] Refresh network list with `r`
  - [ ] Return to compose process list with `q` or `Esc`

🤖 Generated with [Claude Code](https://claude.ai/code)