### PR TITLE
refactor: add ImageListViewModel and VolumeListViewModel

### DIFF
--- a/internal/ui/keyhandler.go
+++ b/internal/ui/keyhandler.go
@@ -486,63 +486,35 @@ func (m *Model) GetStyledHelpText() string {
 
 // Image list handlers
 func (m *Model) SelectUpImage(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if m.selectedDockerImage > 0 {
-		m.selectedDockerImage--
-	}
-	return m, nil
+	return m, m.imageListViewModel.HandleSelectUp()
 }
 
 func (m *Model) SelectDownImage(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if m.selectedDockerImage < len(m.dockerImages)-1 {
-		m.selectedDockerImage++
-	}
-	return m, nil
+	return m, m.imageListViewModel.HandleSelectDown()
 }
 
 func (m *Model) ShowImageList(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	m.currentView = ImageListView
-	m.loading = true
-	return m, loadDockerImages(m.dockerClient, m.imageListViewModel.showAll)
+	return m, m.imageListViewModel.Show(m)
 }
 
 func (m *Model) ToggleAllImages(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	m.imageListViewModel.showAll = !m.imageListViewModel.showAll
-	m.loading = true
-	return m, loadDockerImages(m.dockerClient, m.imageListViewModel.showAll)
+	return m, m.imageListViewModel.HandleToggleAll(m)
 }
 
 func (m *Model) DeleteImage(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if m.selectedDockerImage < len(m.dockerImages) {
-		image := m.dockerImages[m.selectedDockerImage]
-		m.loading = true
-		return m, removeImage(m.dockerClient, image.GetRepoTag(), false)
-	}
-	return m, nil
+	return m, m.imageListViewModel.HandleDelete(m)
 }
 
 func (m *Model) ForceDeleteImage(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if m.selectedDockerImage < len(m.dockerImages) {
-		image := m.dockerImages[m.selectedDockerImage]
-		m.loading = true
-		return m, removeImage(m.dockerClient, image.GetRepoTag(), true)
-	}
-	return m, nil
+	return m, m.imageListViewModel.HandleForceDelete(m)
 }
 
 func (m *Model) BackFromImageList(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	m.currentView = ComposeProcessListView
-	return m, loadProcesses(m.dockerClient, m.projectName, m.composeProcessListViewModel.showAll)
+	return m, m.imageListViewModel.HandleBack(m)
 }
 
 func (m *Model) ShowImageInspect(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if m.selectedDockerImage < len(m.dockerImages) {
-		image := m.dockerImages[m.selectedDockerImage]
-		m.inspectImageID = image.ID
-		m.inspectContainerID = "" // Clear container ID
-		m.loading = true
-		return m, loadImageInspect(m.dockerClient, image.ID)
-	}
-	return m, nil
+	return m, m.imageListViewModel.HandleInspect(m)
 }
 
 // Network list handlers

--- a/internal/ui/keyhandler_volume.go
+++ b/internal/ui/keyhandler_volume.go
@@ -2,93 +2,35 @@ package ui
 
 import (
 	tea "github.com/charmbracelet/bubbletea"
-
-	"github.com/tokuhirom/dcv/internal/docker"
 )
 
 // Volume navigation handlers
 func (m *Model) SelectUpVolume(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if m.selectedDockerVolume > 0 {
-		m.selectedDockerVolume--
-	}
-	return m, nil
+	return m, m.volumeListViewModel.HandleSelectUp()
 }
 
 func (m *Model) SelectDownVolume(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if m.selectedDockerVolume < len(m.dockerVolumes)-1 {
-		m.selectedDockerVolume++
-	}
-	return m, nil
+	return m, m.volumeListViewModel.HandleSelectDown()
 }
 
 // View change handlers
 func (m *Model) ShowVolumeList(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	m.currentView = VolumeListView
-	m.loading = true
-	m.selectedDockerVolume = 0
-	m.err = nil
-	return m, loadDockerVolumes(m.dockerClient)
+	return m, m.volumeListViewModel.Show(m)
 }
 
 func (m *Model) BackFromVolumeList(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	m.currentView = ComposeProcessListView
-	m.err = nil
-	return m, loadProcesses(m.dockerClient, m.projectName, m.composeProcessListViewModel.showAll)
+	return m, m.volumeListViewModel.HandleBack(m)
 }
 
 // Action handlers
 func (m *Model) ShowVolumeInspect(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if len(m.dockerVolumes) == 0 || m.selectedDockerVolume >= len(m.dockerVolumes) {
-		return m, nil
-	}
-
-	volume := m.dockerVolumes[m.selectedDockerVolume]
-	m.loading = true
-	m.err = nil
-	m.inspectVolumeID = volume.Name
-	m.currentView = InspectView
-
-	return m, inspectVolume(m.dockerClient, volume.Name)
+	return m, m.volumeListViewModel.HandleInspect(m)
 }
 
 func (m *Model) DeleteVolume(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if len(m.dockerVolumes) == 0 || m.selectedDockerVolume >= len(m.dockerVolumes) {
-		return m, nil
-	}
-
-	volume := m.dockerVolumes[m.selectedDockerVolume]
-	m.loading = true
-	m.err = nil
-
-	return m, removeVolume(m.dockerClient, volume.Name, false)
+	return m, m.volumeListViewModel.HandleDelete(m)
 }
 
 func (m *Model) ForceDeleteVolume(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if len(m.dockerVolumes) == 0 || m.selectedDockerVolume >= len(m.dockerVolumes) {
-		return m, nil
-	}
-
-	volume := m.dockerVolumes[m.selectedDockerVolume]
-	m.loading = true
-	m.err = nil
-
-	return m, removeVolume(m.dockerClient, volume.Name, true)
-}
-
-// Command functions
-func inspectVolume(dockerClient *docker.Client, volumeID string) tea.Cmd {
-	return func() tea.Msg {
-		output, err := dockerClient.InspectVolume(volumeID)
-		if err != nil {
-			return errorMsg{err: err}
-		}
-		return inspectLoadedMsg{content: output}
-	}
-}
-
-func removeVolume(dockerClient *docker.Client, volumeName string, force bool) tea.Cmd {
-	return func() tea.Msg {
-		err := dockerClient.RemoveVolume(volumeName, force)
-		return serviceActionCompleteMsg{err: err}
-	}
+	return m, m.volumeListViewModel.HandleForceDelete(m)
 }

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -115,9 +115,6 @@ type Model struct {
 	networkListViewModel         NetworkListViewModel
 	statsViewModel               StatsViewModel
 
-	// Docker images state
-	dockerImages        []models.DockerImage
-	selectedDockerImage int
 
 	// Docker volumes state
 	dockerVolumes        []models.DockerVolume

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -114,11 +114,7 @@ type Model struct {
 	helpViewModel                HelpViewModel
 	networkListViewModel         NetworkListViewModel
 	statsViewModel               StatsViewModel
-
-
-	// Docker volumes state
-	dockerVolumes        []models.DockerVolume
-	selectedDockerVolume int
+	volumeListViewModel          VolumeListViewModel
 
 	// File browser state
 	containerFiles        []models.ContainerFile

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -187,11 +187,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.err = msg.err
 			return m, nil
 		}
-		m.dockerImages = msg.images
+		m.imageListViewModel.Loaded(msg.images)
 		m.err = nil
-		if len(m.dockerImages) > 0 && m.selectedDockerImage >= len(m.dockerImages) {
-			m.selectedDockerImage = 0
-		}
 		return m, nil
 
 	case dockerNetworksLoadedMsg:

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -134,6 +134,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, loadDockerContainers(m.dockerClient, m.dockerContainerListViewModel.showAll)
 		case NetworkListView:
 			return m, m.networkListViewModel.HandleRefresh(m)
+		case VolumeListView:
+			return m, m.volumeListViewModel.HandleRefresh(m)
 		default:
 			return m, loadProcesses(m.dockerClient, m.projectName, m.dockerContainerListViewModel.showAll)
 		}
@@ -207,11 +209,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.err = msg.err
 			return m, nil
 		}
-		m.dockerVolumes = msg.volumes
+		m.volumeListViewModel.Loaded(msg.volumes)
 		m.err = nil
-		if len(m.dockerVolumes) > 0 && m.selectedDockerVolume >= len(m.dockerVolumes) {
-			m.selectedDockerVolume = 0
-		}
 		return m, nil
 
 	case containerFilesLoadedMsg:
@@ -297,7 +296,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case NetworkListView:
 			return m, m.networkListViewModel.HandleRefresh(m)
 		case VolumeListView:
-			return m, loadDockerVolumes(m.dockerClient)
+			return m, m.volumeListViewModel.HandleRefresh(m)
 		case FileBrowserView:
 			return m, loadContainerFiles(m.dockerClient, m.browsingContainerID, m.currentPath)
 		case FileContentView:
@@ -662,7 +661,7 @@ func (m *Model) refreshCurrentView() tea.Cmd {
 	case NetworkListView:
 		return loadDockerNetworks(m.dockerClient)
 	case VolumeListView:
-		return loadDockerVolumes(m.dockerClient)
+		return m.volumeListViewModel.HandleRefresh(m)
 	case ComposeProjectListView:
 		return loadProjects(m.dockerClient)
 	case DindProcessListView:

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -296,7 +296,7 @@ func (m *Model) viewBody(availableHeight int) string {
 	case DockerContainerListView:
 		return m.dockerContainerListViewModel.renderDockerList(availableHeight)
 	case ImageListView:
-		return m.renderImageList(availableHeight)
+		return m.imageListViewModel.render(m, availableHeight)
 	case NetworkListView:
 		return m.networkListViewModel.render(m, availableHeight)
 	case VolumeListView:

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -300,7 +300,7 @@ func (m *Model) viewBody(availableHeight int) string {
 	case NetworkListView:
 		return m.networkListViewModel.render(m, availableHeight)
 	case VolumeListView:
-		return m.renderVolumeList()
+		return m.volumeListViewModel.render(m, availableHeight)
 	case FileBrowserView:
 		return m.renderFileBrowser(availableHeight)
 	case FileContentView:


### PR DESCRIPTION
## Summary
- Refactored both Image List and Volume List views to use ViewModel pattern for better separation of concerns
- Follows the established pattern used in other views (NetworkListViewModel, StatsViewModel, etc.)

## Changes

### ImageListViewModel
- Created `ImageListViewModel` struct with `dockerImages`, `selectedDockerImage`, and `showAll` fields
- Added methods: `render()`, `Show()`, `HandleSelectUp/Down()`, `HandleToggleAll()`, `HandleDelete()`, `HandleForceDelete()`, `HandleInspect()`, `HandleBack()`, `HandleRefresh()`, and `Loaded()`
- Moved image-related state from Model to ImageListViewModel
- Maintained compatibility with existing `GetRepoTag()` usage for image deletion

### VolumeListViewModel
- Created `VolumeListViewModel` struct with `dockerVolumes` and `selectedDockerVolume` fields
- Added methods: `render()`, `Show()`, `HandleSelectUp/Down()`, `HandleInspect()`, `HandleDelete()`, `HandleForceDelete()`, `HandleBack()`, `HandleRefresh()`, and `Loaded()`
- Moved volume-related state from Model to VolumeListViewModel
- Migrated `inspectVolume` and `removeVolume` functions from keyhandler_volume.go to view_volume_list.go
- Added VolumeListView case to service action complete handling

## Test plan
- [x] Ran existing tests - all pass
- [x] Manually tested image list functionality (navigation, toggle all, delete, inspect)
- [x] Manually tested volume list functionality (navigation, delete, inspect)
- [x] Verified proper state management and view switching

🤖 Generated with [Claude Code](https://claude.ai/code)