### PR TITLE
refactor: Remove empty DeleteContainer method

### DIFF
--- a/internal/ui/keyhandler.go
+++ b/internal/ui/keyhandler.go
@@ -203,10 +203,6 @@ func (m *Model) CmdTop(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func (m *Model) DeleteContainer(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	return m, nil
-}
-
 func (m *Model) DeployProject(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, m.commandExecutionViewModel.ExecuteComposeCommand(m, "up")
 }


### PR DESCRIPTION
## Summary
- Removed the empty `DeleteContainer` method from `internal/ui/keyhandler.go`
- This method was not referenced anywhere in the codebase and only returned `m, nil`

## Test plan
- [x] Verified the method is not called anywhere using grep
- [x] Code compiles successfully after removal
- [ ] All existing functionality continues to work

🤖 Generated with [Claude Code](https://claude.ai/code)