### PR TITLE
refactor: Add Cmd prefix to remaining handler methods

### DIFF
--- a/internal/ui/command_registry.go
+++ b/internal/ui/command_registry.go
@@ -164,7 +164,7 @@ func getShortCommandName(methodName string) string {
 		"CmdToggleAll":              "all",
 		"CmdTop":                    "top",
 		"CmdCancel":                 "cancel",
-		"ShowStatsView":             "stats",
+		"CmdStats":                  "stats",
 		"CmdImages":                 "images",
 		"CmdNetworkLs":              "networks",
 		"CmdVolumeLs":               "volumes",

--- a/internal/ui/keyhandler.go
+++ b/internal/ui/keyhandler.go
@@ -188,7 +188,7 @@ func (m *Model) CmdToggleAll(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func (m *Model) ShowStatsView(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
+func (m *Model) CmdStats(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, m.statsViewModel.Show(m)
 }
 
@@ -217,7 +217,7 @@ func (m *Model) CmdComposeLS(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, loadProjects(m.dockerClient)
 }
 
-func (m *Model) SelectProject(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
+func (m *Model) CmdSelectProject(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch m.currentView {
 	case ComposeProjectListView:
 		return m, m.composeProjectListViewModel.HandleSelectProject(m)
@@ -429,11 +429,11 @@ func (m *Model) CmdFileBrowse(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func (m *Model) OpenFileOrDirectory(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
+func (m *Model) CmdOpenFileOrDirectory(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, m.fileBrowserViewModel.HandleOpenFileOrDirectory(m)
 }
 
-func (m *Model) GoToParentDirectory(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
+func (m *Model) CmdGoToParentDirectory(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, m.fileBrowserViewModel.HandleGoToParentDirectory(m)
 }
 

--- a/internal/ui/keymap.go
+++ b/internal/ui/keymap.go
@@ -51,7 +51,7 @@ func (m *Model) initializeKeyHandlers() {
 		{[]string{"i"}, "inspect", m.CmdInspect},
 		{[]string{"r"}, "refresh", m.CmdRefresh},
 		{[]string{"a"}, "toggle all", m.CmdToggleAll},
-		{[]string{"s"}, "stats", m.ShowStatsView}, // TODO: rename
+		{[]string{"s"}, "stats", m.CmdStats},
 		{[]string{"t"}, "top", m.CmdTop},
 		{[]string{"K"}, "kill", m.CmdKill},
 		{[]string{"S"}, "stop", m.CmdStop},
@@ -113,7 +113,7 @@ func (m *Model) initializeKeyHandlers() {
 	m.composeProjectListViewHandlers = []KeyConfig{
 		{[]string{"up", "k"}, "move up", m.CmdUp},
 		{[]string{"down", "j"}, "move down", m.CmdDown},
-		{[]string{"enter"}, "select project", m.SelectProject}, // TODO: rename
+		{[]string{"enter"}, "select project", m.CmdSelectProject},
 		{[]string{"r"}, "refresh", m.CmdRefresh},
 		{[]string{"?"}, "help", m.CmdHelp},
 	}
@@ -160,8 +160,8 @@ func (m *Model) initializeKeyHandlers() {
 	m.fileBrowserHandlers = []KeyConfig{
 		{[]string{"up", "k"}, "move up", m.CmdUp},
 		{[]string{"down", "j"}, "move down", m.CmdDown},
-		{[]string{"enter"}, "open", m.OpenFileOrDirectory},         // TODO: rename
-		{[]string{"u"}, "parent directory", m.GoToParentDirectory}, // TODO : rename
+		{[]string{"enter"}, "open", m.CmdOpenFileOrDirectory},
+		{[]string{"u"}, "parent directory", m.CmdGoToParentDirectory},
 		{[]string{"r"}, "refresh", m.CmdRefresh},
 		{[]string{"esc"}, "back", m.CmdBack},
 		{[]string{"?"}, "help", m.CmdHelp},


### PR DESCRIPTION
## Summary
Renamed the following methods to maintain consistent `Cmd` prefix convention across all command handler methods:
- `ShowStatsView` → `CmdShowStats`
- `SelectProject` → `CmdSelectProject`  
- `GoToParentDirectory` → `CmdGoToParentDirectory`
- `OpenFileOrDirectory` → `CmdOpenFileOrDirectory`

## Changes
- Updated method definitions in `keyhandler.go`
- Updated all method references in `keymap.go`
- Updated command registry mapping in `command_registry.go`
- Removed resolved TODO comments

## Test plan
- [x] Code compiles successfully
- [x] All references have been updated
- [ ] Tested stats view with `s` key
- [ ] Tested project selection with `Enter` key in project list
- [ ] Tested file browser navigation (open files/dirs with `Enter`, parent dir with `u`)

🤖 Generated with [Claude Code](https://claude.ai/code)