### PR TITLE
fix: Remove deprecated :set command

### DIFF
--- a/internal/ui/command.go
+++ b/internal/ui/command.go
@@ -135,20 +135,6 @@ func (m *CommandViewModel) executeCommand(model *Model) (tea.Model, tea.Cmd) {
 		}
 		return model, model.helpViewModel.Show(model, model.currentView)
 
-	case "set": // TODO: deprecate this
-		// Handle set commands (e.g., :set showAll)
-		if len(parts) > 1 {
-			switch parts[1] {
-			case "all", "showAll":
-				model.composeProcessListViewModel.showAll = true
-				return model, model.refreshCurrentView()
-			case "noall", "noshowAll":
-				model.composeProcessListViewModel.showAll = false
-				return model, model.refreshCurrentView()
-			}
-		}
-		return model, nil
-
 	default:
 		// Try to execute as a key handler command
 		return m.executeKeyHandlerCommand(model, parts[0])

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -451,29 +451,6 @@ func (m *Model) handleQuitConfirmation(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func (m *Model) refreshCurrentView() tea.Cmd { // TODO: deprecate
-	switch m.currentView {
-	case ComposeProcessListView:
-		return loadProcesses(m.dockerClient, m.projectName, m.composeProcessListViewModel.showAll)
-	case DockerContainerListView:
-		return loadDockerContainers(m.dockerClient, m.dockerContainerListViewModel.showAll)
-	case ImageListView:
-		return loadDockerImages(m.dockerClient, m.imageListViewModel.showAll)
-	case NetworkListView:
-		return loadDockerNetworks(m.dockerClient)
-	case VolumeListView:
-		return m.volumeListViewModel.HandleRefresh(m)
-	case ComposeProjectListView:
-		return loadProjects(m.dockerClient)
-	case DindProcessListView:
-		return m.dindProcessListViewModel.HandleRefresh(m)
-	case FileBrowserView:
-		return m.fileBrowserViewModel.HandleRefresh(m)
-	default:
-		return nil
-	}
-}
-
 func (m *Model) handleTopViewKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	handler, ok := m.topViewKeymap[msg.String()]
 	if ok {


### PR DESCRIPTION
## Summary
Removes the `:set` command that was marked with TODO for deprecation.

## Changes
- Removed the `set` case from the command switch statement in `command.go`
- This included removal of `:set all`, `:set noall`, `:set showAll`, and `:set noshowAll` commands

## Motivation
The `:set` command was marked with `// TODO: deprecate this` comment. The functionality to toggle showing all containers is already available through the 'a' key binding, making the `:set` command redundant.

## Test plan
- [x] All tests pass
- [x] Verified that the 'a' key still toggles showing all containers
- [ ] Confirmed `:set` command no longer works

Closes #98

🤖 Generated with [Claude Code](https://claude.ai/code)