### PR TITLE
refactor: Use CommandExecutionView for network, image, and volume deletion

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -466,32 +466,12 @@ func loadDockerImages(client *docker.Client, showAll bool) tea.Cmd {
 	}
 }
 
-func removeImage(client *docker.Client, imageID string, force bool) tea.Cmd {
-	return func() tea.Msg {
-		err := client.RemoveImage(imageID, force)
-		return serviceActionCompleteMsg{
-			service: imageID,
-			err:     err,
-		}
-	}
-}
-
 func loadDockerNetworks(client *docker.Client) tea.Cmd {
 	return func() tea.Msg {
 		networks, err := client.ListNetworks()
 		return dockerNetworksLoadedMsg{
 			networks: networks,
 			err:      err,
-		}
-	}
-}
-
-func removeNetwork(client *docker.Client, networkID string) tea.Cmd {
-	return func() tea.Msg {
-		err := client.RemoveNetwork(networkID)
-		return serviceActionCompleteMsg{
-			service: networkID,
-			err:     err,
 		}
 	}
 }

--- a/internal/ui/view_image_list.go
+++ b/internal/ui/view_image_list.go
@@ -111,8 +111,9 @@ func (m *ImageListViewModel) HandleDelete(model *Model) tea.Cmd {
 		return nil
 	}
 	image := m.dockerImages[m.selectedDockerImage]
-	model.loading = true
-	return removeImage(model.dockerClient, image.GetRepoTag(), false)
+	// Use CommandExecutionView to show real-time output
+	args := []string{"rmi", image.GetRepoTag()}
+	return model.commandExecutionViewModel.ExecuteCommand(model, args...)
 }
 
 // HandleInspect shows the inspect view for the selected image

--- a/internal/ui/view_image_list_test.go
+++ b/internal/ui/view_image_list_test.go
@@ -188,7 +188,10 @@ func TestImageListViewModel_Operations(t *testing.T) {
 	})
 
 	t.Run("HandleDelete removes selected image", func(t *testing.T) {
-		model := &Model{loading: false}
+		model := &Model{
+			loading:                  false,
+			commandExecutionViewModel: CommandExecutionViewModel{},
+		}
 		vm := &ImageListViewModel{
 			dockerImages: []models.DockerImage{
 				{ID: "image1"},
@@ -199,7 +202,7 @@ func TestImageListViewModel_Operations(t *testing.T) {
 
 		cmd := vm.HandleDelete(model)
 
-		assert.True(t, model.loading)
+		// Command execution doesn't set loading anymore, it switches view
 		assert.NotNil(t, cmd)
 	})
 

--- a/internal/ui/view_image_list_test.go
+++ b/internal/ui/view_image_list_test.go
@@ -189,7 +189,7 @@ func TestImageListViewModel_Operations(t *testing.T) {
 
 	t.Run("HandleDelete removes selected image", func(t *testing.T) {
 		model := &Model{
-			loading:                  false,
+			loading:                   false,
 			commandExecutionViewModel: CommandExecutionViewModel{},
 		}
 		vm := &ImageListViewModel{

--- a/internal/ui/view_network_list.go
+++ b/internal/ui/view_network_list.go
@@ -81,8 +81,9 @@ func (m *NetworkListViewModel) HandleDelete(model *Model) tea.Cmd {
 			model.err = fmt.Errorf("cannot remove default network: %s", network.Name)
 			return nil
 		}
-		model.loading = true
-		return removeNetwork(model.dockerClient, network.ID)
+		// Use CommandExecutionView to show real-time output
+		args := []string{"network", "rm", network.ID}
+		return model.commandExecutionViewModel.ExecuteCommand(model, args...)
 	}
 	return nil
 }

--- a/internal/ui/view_volume_list.go
+++ b/internal/ui/view_volume_list.go
@@ -90,10 +90,13 @@ func (m *VolumeListViewModel) HandleDelete(model *Model, force bool) tea.Cmd {
 	}
 
 	volume := m.dockerVolumes[m.selectedDockerVolume]
-	model.loading = true
-	model.err = nil
-
-	return removeVolume(model.dockerClient, volume.Name, force)
+	// Use CommandExecutionView to show real-time output
+	args := []string{"volume", "rm"}
+	if force {
+		args = append(args, "-f")
+	}
+	args = append(args, volume.Name)
+	return model.commandExecutionViewModel.ExecuteCommand(model, args...)
 }
 
 // HandleBack returns to the compose process list view
@@ -120,12 +123,5 @@ func loadDockerVolumes(dockerClient *docker.Client) tea.Cmd {
 	return func() tea.Msg {
 		volumes, err := dockerClient.ListVolumes()
 		return dockerVolumesLoadedMsg{volumes: volumes, err: err}
-	}
-}
-
-func removeVolume(dockerClient *docker.Client, volumeName string, force bool) tea.Cmd {
-	return func() tea.Msg {
-		err := dockerClient.RemoveVolume(volumeName, force)
-		return serviceActionCompleteMsg{err: err}
 	}
 }


### PR DESCRIPTION
## Summary
- Network removal now uses CommandExecutionView to show real-time output
- Image removal now uses CommandExecutionView to show real-time output  
- Volume removal now uses CommandExecutionView to show real-time output
- Removed unused removeNetwork, removeImage, and removeVolume wrapper functions
- Updated tests to match new behavior

## Why this change?
This provides better user feedback when deleting resources by showing the actual Docker command output in real-time, similar to how we handle other Docker operations.

## Test plan
- [x] All tests pass
- [x] Network deletion shows command output
- [x] Image deletion shows command output
- [x] Volume deletion shows command output

🤖 Generated with [Claude Code](https://claude.ai/code)