### PR TITLE
Clean up Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,60 +1,35 @@
-.PHONY: all up down logs test-dind clean staticcheck test fmt dev-deps lint
+.PHONY: all test fmt dev-deps lint clean
 
 all:
 	go build -o dcv
 
-# Start all services
-up:
-	docker compose up -d
-	@echo "Waiting for services to start..."
-	@sleep 5
-	@echo "Starting containers inside dind..."
-	@docker compose exec -T dind sh /startup.sh || true
-
-# Stop all services
-down:
-	docker compose down -v
-
-# Show logs
-logs:
-	docker compose logs -f
-
-# Setup dind containers
-test-dind:
-	docker compose exec -T dind sh /startup.sh
-
-# Clean everything
-clean:
-	docker compose down -v
-	rm -f dcv
-
-# Run golangci-lint
-lint:
-	@which golangci-lint > /dev/null || $(MAKE) install-golangci-lint
-	golangci-lint run
-
-# Install golangci-lint
-install-golangci-lint:
-	@echo "Installing golangci-lint..."
-	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
-	@echo "golangci-lint installed successfully"
-
-# Run staticcheck (kept for backward compatibility)
-staticcheck: lint
-
+# Run tests
 test:
 	go test -v ./...
 
-# Format code with goimports (fallback to go fmt if goimports fails)
+# Format code with golangci-lint
 fmt:
 	@echo "Running code formatter..."
 	golangci-lint fmt .
+
+# Run golangci-lint
+lint:
+	@which golangci-lint > /dev/null || $(MAKE) dev-deps
+	golangci-lint run
+
+# Clean build artifacts
+clean:
+	rm -f dcv
 
 # Install development dependencies
 dev-deps:
 	@echo "Installing development dependencies..."
 	@go install golang.org/x/tools/cmd/goimports@latest
-	@which golangci-lint > /dev/null || $(MAKE) install-golangci-lint
+	@which golangci-lint > /dev/null || { \
+		echo "Installing golangci-lint..."; \
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin latest; \
+		echo "golangci-lint installed successfully"; \
+	}
 	@which lefthook > /dev/null || go install github.com/evilmartians/lefthook@latest
 	@lefthook install
 	@echo "Development dependencies installed successfully"


### PR DESCRIPTION
## Summary
- Removed staticcheck task (replaced by golangci-lint)
- Merged install-golangci-lint into dev-deps target
- Removed Docker Compose related tasks (up, down, logs, test-dind)
- Simplified clean target to only remove build artifacts

## Why?
Simplify the Makefile by removing deprecated and compose-specific targets. The staticcheck task was redundant since we use golangci-lint, and the Docker Compose tasks weren't essential for the build process.

## Test plan
- [x] `make fmt` - Code formatting works
- [x] `make test` - Tests pass
- [x] `make lint` - Linting works
- [x] `make dev-deps` - Development dependencies install correctly
- [x] `make clean` - Cleans build artifacts

🤖 Generated with [Claude Code](https://claude.ai/code)