### PR TITLE
refactor: Move CmdCancel to keyhandler.go

### DIFF
--- a/internal/ui/keyhandler.go
+++ b/internal/ui/keyhandler.go
@@ -35,6 +35,20 @@ func (m *Model) CmdRefresh(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 }
 
+// CmdCancel handles cancel/escape key for views that support it
+func (m *Model) CmdCancel(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch m.currentView {
+	case CommandExecutionView:
+		return m, m.commandExecutionViewModel.HandleCancel()
+	case LogView:
+		return m, m.logViewModel.HandleCancel()
+	default:
+		slog.Info("Cancel command not implemented for current view",
+			slog.String("current_view", m.currentView.String()))
+		return m, nil
+	}
+}
+
 func (m *Model) CmdUp(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch m.currentView {
 	case NetworkListView:

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -204,20 +204,6 @@ func (m *Model) Init() tea.Cmd {
 	}
 }
 
-// TODO: move to keyhandler.go
-func (m *Model) CmdCancel(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	switch m.currentView {
-	case CommandExecutionView:
-		return m, m.commandExecutionViewModel.HandleCancel()
-	case LogView:
-		return m, m.logViewModel.HandleCancel()
-	default:
-		slog.Info("Cancel command not implemented for current view",
-			slog.String("current_view", m.currentView.String()))
-		return m, nil
-	}
-}
-
 func (m *Model) SwitchView(view ViewType) {
 	if view == m.currentView {
 		slog.Info("SwitchView called with the same view, ignoring",


### PR DESCRIPTION
## Summary
- Moved CmdCancel method from model.go to keyhandler.go where it belongs with other Cmd* methods

## Why?
The code had a TODO comment indicating this method should be moved to keyhandler.go. This improves code organization by keeping all Cmd* key handler methods in the same file.

## Test plan
- [x] All tests pass
- [x] No functional changes, just code organization

🤖 Generated with [Claude Code](https://claude.ai/code)