### PR TITLE
fix: Use CommandExecutionView for pause/unpause operations

### DIFF
--- a/internal/ui/keyhandler_docker.go
+++ b/internal/ui/keyhandler_docker.go
@@ -58,20 +58,26 @@ func (m *Model) CmdPause(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Check if selected container is paused
 		if m.composeProcessListViewModel.selectedContainer < len(m.composeProcessListViewModel.composeContainers) {
 			selected := m.composeProcessListViewModel.composeContainers[m.composeProcessListViewModel.selectedContainer]
+			var args []string
 			if selected.State == "paused" {
-				return m, unpauseService(m.dockerClient, selected.ID)
+				args = []string{"unpause", selected.ID}
+			} else {
+				args = []string{"pause", selected.ID}
 			}
-			return m, pauseService(m.dockerClient, selected.ID)
+			return m, m.commandExecutionViewModel.ExecuteCommand(m, args...)
 		}
 		return m, nil
 	case DockerContainerListView:
-		// Docker container list doesn't have pause/unpause yet, could be added
+		// Docker container list pause/unpause support
 		if m.dockerContainerListViewModel.selectedDockerContainer < len(m.dockerContainerListViewModel.dockerContainers) {
 			selected := m.dockerContainerListViewModel.dockerContainers[m.dockerContainerListViewModel.selectedDockerContainer]
+			var args []string
 			if strings.Contains(selected.Status, "Paused") {
-				return m, unpauseService(m.dockerClient, selected.ID)
+				args = []string{"unpause", selected.ID}
+			} else {
+				args = []string{"pause", selected.ID}
 			}
-			return m, pauseService(m.dockerClient, selected.ID)
+			return m, m.commandExecutionViewModel.ExecuteCommand(m, args...)
 		}
 		return m, nil
 	default:

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -376,26 +376,6 @@ func removeService(client *docker.Client, containerID string) tea.Cmd {
 	}
 }
 
-func pauseService(client *docker.Client, containerID string) tea.Cmd {
-	return func() tea.Msg {
-		err := client.PauseContainer(containerID)
-		return serviceActionCompleteMsg{
-			service: containerID,
-			err:     err,
-		}
-	}
-}
-
-func unpauseService(client *docker.Client, containerID string) tea.Cmd {
-	return func() tea.Msg {
-		err := client.UnpauseContainer(containerID)
-		return serviceActionCompleteMsg{
-			service: containerID,
-			err:     err,
-		}
-	}
-}
-
 func loadStats(client *docker.Client) tea.Cmd {
 	return func() tea.Msg {
 		// TODO: support periodic update


### PR DESCRIPTION
## Summary
- Changed pause and unpause operations to use CommandExecutionView for real-time output
- Removed unused pauseService and unpauseService functions

## Why?
For consistency with other Docker operations, pause/unpause should use CommandExecutionView to show real-time command execution output to the user, rather than executing silently in the background.

## Changes
- Updated CmdPause in keyhandler_docker.go to use CommandExecutionView
- Removed the now-unused pauseService and unpauseService functions from model.go

## Test plan
- [x] All tests pass
- [x] Pause/unpause operations now show real-time output in CommandExecutionView

🤖 Generated with [Claude Code](https://claude.ai/code)