### PR TITLE
refactor: Use CommandExecutionView for all remove operations

### DIFF
--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -128,25 +128,6 @@ func (c *Client) ListImages(showAll bool) ([]models.DockerImage, error) {
 	return images, nil
 }
 
-func (c *Client) RemoveImage(imageID string, force bool) error {
-	args := []string{"rmi"}
-	if force {
-		args = append(args, "-f")
-	}
-	args = append(args, imageID)
-
-	output, err := ExecuteCaptured(args...)
-	if err != nil {
-		return fmt.Errorf("failed to remove image: %w\nOutput: %s", err, string(output))
-	}
-
-	slog.Info("Removed image",
-		slog.String("imageID", imageID),
-		slog.String("output", string(output)))
-
-	return nil
-}
-
 func (c *Client) ListNetworks() ([]models.DockerNetwork, error) {
 	output, err := ExecuteCaptured("network", "ls", "--format", "json")
 	if err != nil {
@@ -159,19 +140,6 @@ func (c *Client) ListNetworks() ([]models.DockerNetwork, error) {
 	}
 
 	return networks, nil
-}
-
-func (c *Client) RemoveNetwork(networkID string) error {
-	output, err := ExecuteCaptured([]string{"network", "rm", networkID}...)
-	if err != nil {
-		return fmt.Errorf("failed to remove network: %w\nOutput: %s", err, string(output))
-	}
-
-	slog.Info("Removed network",
-		slog.String("networkID", networkID),
-		slog.String("output", string(output)))
-
-	return nil
 }
 
 func (c *Client) ListContainerFiles(containerID, path string) ([]models.ContainerFile, error) {

--- a/internal/docker/interfaces.go
+++ b/internal/docker/interfaces.go
@@ -17,13 +17,10 @@ type DockerClient interface {
 	StopContainer(containerID string) error
 	StartContainer(containerID string) error
 	RestartContainer(containerID string) error
-	RemoveContainer(containerID string) error
 	GetStats() (string, error)
 	ListAllContainers(showAll bool) ([]models.DockerContainer, error)
 	ListImages(showAll bool) ([]models.DockerImage, error)
-	RemoveImage(imageID string, force bool) error
 	ListNetworks() ([]models.DockerNetwork, error)
-	RemoveNetwork(networkID string) error
 	ListContainerFiles(containerID, path string) ([]models.ContainerFile, error)
 	ReadContainerFile(containerID, path string) (string, error)
 	ExecuteInteractive(containerID string, command []string) error
@@ -31,7 +28,6 @@ type DockerClient interface {
 	InspectImage(imageID string) (string, error)
 	InspectNetwork(networkID string) (string, error)
 	ListVolumes() ([]models.DockerVolume, error)
-	RemoveVolume(volumeName string, force bool) error
 	InspectVolume(volumeName string) (string, error)
 }
 
@@ -42,7 +38,6 @@ type ComposeClientInterface interface {
 	StopService(serviceName string) error
 	StartService(serviceName string) error
 	RestartService(serviceName string) error
-	RemoveService(serviceName string) error
 	Top() (string, error)
 	Up(detach bool) error
 	Down() error

--- a/internal/docker/mock_docker.go
+++ b/internal/docker/mock_docker.go
@@ -308,62 +308,6 @@ func (mr *MockDockerClientMockRecorder) ReadContainerFile(containerID, path any)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadContainerFile", reflect.TypeOf((*MockDockerClient)(nil).ReadContainerFile), containerID, path)
 }
 
-// RemoveContainer mocks base method.
-func (m *MockDockerClient) RemoveContainer(containerID string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveContainer", containerID)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RemoveContainer indicates an expected call of RemoveContainer.
-func (mr *MockDockerClientMockRecorder) RemoveContainer(containerID any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveContainer", reflect.TypeOf((*MockDockerClient)(nil).RemoveContainer), containerID)
-}
-
-// RemoveImage mocks base method.
-func (m *MockDockerClient) RemoveImage(imageID string, force bool) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveImage", imageID, force)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RemoveImage indicates an expected call of RemoveImage.
-func (mr *MockDockerClientMockRecorder) RemoveImage(imageID, force any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveImage", reflect.TypeOf((*MockDockerClient)(nil).RemoveImage), imageID, force)
-}
-
-// RemoveNetwork mocks base method.
-func (m *MockDockerClient) RemoveNetwork(networkID string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveNetwork", networkID)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RemoveNetwork indicates an expected call of RemoveNetwork.
-func (mr *MockDockerClientMockRecorder) RemoveNetwork(networkID any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveNetwork", reflect.TypeOf((*MockDockerClient)(nil).RemoveNetwork), networkID)
-}
-
-// RemoveVolume mocks base method.
-func (m *MockDockerClient) RemoveVolume(volumeName string, force bool) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveVolume", volumeName, force)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RemoveVolume indicates an expected call of RemoveVolume.
-func (mr *MockDockerClientMockRecorder) RemoveVolume(volumeName, force any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveVolume", reflect.TypeOf((*MockDockerClient)(nil).RemoveVolume), volumeName, force)
-}
-
 // RestartContainer mocks base method.
 func (m *MockDockerClient) RestartContainer(containerID string) error {
 	m.ctrl.T.Helper()
@@ -471,20 +415,6 @@ func (m *MockComposeClientInterface) ListContainers(showAll bool) ([]models.Comp
 func (mr *MockComposeClientInterfaceMockRecorder) ListContainers(showAll any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListContainers", reflect.TypeOf((*MockComposeClientInterface)(nil).ListContainers), showAll)
-}
-
-// RemoveService mocks base method.
-func (m *MockComposeClientInterface) RemoveService(serviceName string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveService", serviceName)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RemoveService indicates an expected call of RemoveService.
-func (mr *MockComposeClientInterfaceMockRecorder) RemoveService(serviceName any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveService", reflect.TypeOf((*MockComposeClientInterface)(nil).RemoveService), serviceName)
 }
 
 // RestartService mocks base method.

--- a/internal/docker/volume.go
+++ b/internal/docker/volume.go
@@ -54,26 +54,6 @@ func (c *Client) ListVolumes() ([]models.DockerVolume, error) {
 	return volumes, nil
 }
 
-// RemoveVolume removes a Docker volume
-func (c *Client) RemoveVolume(volumeName string, force bool) error {
-	args := []string{"volume", "rm"}
-	if force {
-		args = append(args, "-f")
-	}
-	args = append(args, volumeName)
-
-	output, err := ExecuteCaptured(args...)
-	if err != nil {
-		return fmt.Errorf("failed to remove volume %s: %w\nOutput: %s", volumeName, err, string(output))
-	}
-
-	slog.Info("Removed volume",
-		slog.String("volumeName", volumeName),
-		slog.String("output", string(output)))
-
-	return nil
-}
-
 // InspectVolume inspects a Docker volume and returns the formatted JSON
 func (c *Client) InspectVolume(volumeName string) (string, error) {
 	output, err := ExecuteCaptured([]string{"volume", "inspect", volumeName}...)

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -268,8 +268,7 @@ type topLoadedMsg struct {
 }
 
 type serviceActionCompleteMsg struct {
-	service string
-	err     error
+	err error
 }
 
 type upActionCompleteMsg struct {
@@ -361,17 +360,6 @@ func loadTop(client *docker.Client, projectName, serviceName string) tea.Cmd {
 		return topLoadedMsg{
 			output: output,
 			err:    err,
-		}
-	}
-}
-
-func removeService(client *docker.Client, containerID string) tea.Cmd {
-	return func() tea.Msg {
-		cmd := client.Execute("rm", "-f", containerID)
-		err := cmd.Wait()
-		return serviceActionCompleteMsg{
-			service: containerID,
-			err:     err,
 		}
 	}
 }

--- a/internal/ui/view_compose_process_list.go
+++ b/internal/ui/view_compose_process_list.go
@@ -163,10 +163,10 @@ func (m *ComposeProcessListViewModel) HandleCommandExecution(model *Model, opera
 func (m *ComposeProcessListViewModel) HandleRemove(model *Model) tea.Cmd {
 	if m.selectedContainer < len(m.composeContainers) {
 		container := m.composeContainers[m.selectedContainer]
-		// Only allow removing stopped composeContainers
+		// Only allow removing stopped containers
 		if !strings.Contains(container.GetStatus(), "Up") && !strings.Contains(container.State, "running") {
-			model.loading = true
-			return removeService(model.dockerClient, container.ID)
+			// Use CommandExecutionView to show real-time output
+			return model.commandExecutionViewModel.ExecuteCommand(model, "rm", "-f", container.ID)
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary
- Removed unused RemoveImage, RemoveNetwork, RemoveVolume methods from docker package  
- Removed unused RemoveContainer and RemoveService methods and their implementations
- Updated ComposeProcessListViewModel.HandleRemove to use CommandExecutionView
- Removed the removeService wrapper function and cleaned up serviceActionCompleteMsg
- Regenerated mocks after interface changes

## Why?
All remove operations now use CommandExecutionView for real-time output, providing better user feedback during container/image/network/volume removal operations. This ensures consistency across all Docker operations and eliminates unnecessary wrapper functions.

## Test plan
- [x] All tests pass
- [x] Linting passes
- [x] Remove operations work correctly with CommandExecutionView

🤖 Generated with [Claude Code](https://claude.ai/code)