### PR TITLE
refactor: Use ViewType.String() in help view

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -236,6 +236,44 @@ func (m *Model) SwitchToPreviousView() {
 	m.currentView = previousView
 }
 
+// GetViewKeyHandlers returns the key handlers for the specified view
+func (m *Model) GetViewKeyHandlers(view ViewType) []KeyConfig {
+	switch view {
+	case ComposeProcessListView:
+		return m.composeProcessListViewHandlers
+	case LogView:
+		return m.logViewHandlers
+	case DindProcessListView:
+		return m.dindListViewHandlers
+	case TopView:
+		return m.topViewHandlers
+	case StatsView:
+		return m.statsViewHandlers
+	case ComposeProjectListView:
+		return m.composeProjectListViewHandlers
+	case DockerContainerListView:
+		return m.dockerContainerListViewHandlers
+	case ImageListView:
+		return m.imageListViewHandlers
+	case NetworkListView:
+		return m.networkListViewHandlers
+	case VolumeListView:
+		return m.volumeListViewHandlers
+	case FileBrowserView:
+		return m.fileBrowserHandlers
+	case FileContentView:
+		return m.fileContentHandlers
+	case InspectView:
+		return m.inspectViewHandlers
+	case HelpView:
+		return m.helpViewHandlers
+	case CommandExecutionView:
+		return m.commandExecHandlers
+	default:
+		return nil
+	}
+}
+
 // Messages
 
 type processesLoadedMsg struct {

--- a/internal/ui/view_help.go
+++ b/internal/ui/view_help.go
@@ -17,56 +17,8 @@ func (m *HelpViewModel) render(model *Model, availableHeight int) string {
 	var s strings.Builder
 
 	// Get key configurations based on previous view
-	var viewConfigs []KeyConfig
-	viewName := ""
-
-	switch m.parentView {
-	case ComposeProcessListView:
-		viewConfigs = model.composeProcessListViewHandlers
-		viewName = "Compose Process List"
-	case LogView:
-		viewConfigs = model.logViewHandlers
-		viewName = "Log View"
-	case DindProcessListView:
-		viewConfigs = model.dindListViewHandlers
-		viewName = "Docker in Docker"
-	case TopView:
-		viewConfigs = model.topViewHandlers
-		viewName = "Process Info"
-	case StatsView:
-		viewConfigs = model.statsViewHandlers
-		viewName = "Container Stats"
-	case ComposeProjectListView:
-		viewConfigs = model.composeProjectListViewHandlers
-		viewName = "Project List"
-	case DockerContainerListView:
-		viewConfigs = model.dockerContainerListViewHandlers
-		viewName = "Docker Containers"
-	case ImageListView:
-		viewConfigs = model.imageListViewHandlers
-		viewName = "Docker Images"
-	case NetworkListView:
-		viewConfigs = model.networkListViewHandlers
-		viewName = "Docker Networks"
-	case VolumeListView:
-		viewConfigs = model.volumeListViewHandlers
-		viewName = "Docker Volumes"
-	case FileBrowserView:
-		viewConfigs = model.fileBrowserHandlers
-		viewName = "File Browser"
-	case FileContentView:
-		viewConfigs = model.fileContentHandlers
-		viewName = "File Content"
-	case InspectView:
-		viewConfigs = model.inspectViewHandlers
-		viewName = "Inspect"
-	case HelpView:
-		viewConfigs = model.helpViewHandlers
-		viewName = "Help"
-	case CommandExecutionView:
-		viewConfigs = model.commandExecHandlers
-		viewName = "Command Execution"
-	}
+	viewConfigs := model.GetViewKeyHandlers(m.parentView)
+	viewName := m.parentView.String()
 
 	// Show view name
 	s.WriteString(headerStyle.Render(fmt.Sprintf("Keyboard shortcuts for: %s", viewName)) + "\n\n")


### PR DESCRIPTION
## Summary
- Replaced duplicate switch statement with ViewType.String() method call
- Removed redundant view name assignments in view_help.go

## Why?
The ViewType already has a String() method that returns the proper display names for each view. Using it eliminates code duplication and ensures consistency.

## Test plan
- [x] All tests pass
- [x] Help view continues to display correct view names

🤖 Generated with [Claude Code](https://claude.ai/code)