### PR TITLE
refactor: Consolidate view-specific key handlers into generic method

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -274,6 +274,44 @@ func (m *Model) GetViewKeyHandlers(view ViewType) []KeyConfig {
 	}
 }
 
+// GetViewKeymap returns the keymap for the specified view
+func (m *Model) GetViewKeymap(view ViewType) map[string]KeyHandler {
+	switch view {
+	case ComposeProcessListView:
+		return m.composeProcessListViewKeymap
+	case LogView:
+		return m.logViewKeymap
+	case DindProcessListView:
+		return m.dindListViewKeymap
+	case TopView:
+		return m.topViewKeymap
+	case StatsView:
+		return m.statsViewKeymap
+	case ComposeProjectListView:
+		return m.composeProjectListViewKeymap
+	case DockerContainerListView:
+		return m.dockerListViewKeymap
+	case ImageListView:
+		return m.imageListViewKeymap
+	case NetworkListView:
+		return m.networkListViewKeymap
+	case VolumeListView:
+		return m.volumeListViewKeymap
+	case FileBrowserView:
+		return m.fileBrowserKeymap
+	case FileContentView:
+		return m.fileContentKeymap
+	case InspectView:
+		return m.inspectViewKeymap
+	case HelpView:
+		return m.helpViewKeymap
+	case CommandExecutionView:
+		return m.commandExecKeymap
+	default:
+		return nil
+	}
+}
+
 // Messages
 
 type processesLoadedMsg struct {

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -316,66 +316,24 @@ func (m *Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	// Handle view-specific keys
-	switch m.currentView {
-	case ComposeProcessListView:
-		return m.handleComposeProcessListKeys(msg)
-	case LogView:
-		return m.handleLogViewKeys(msg)
-	case DindProcessListView:
-		return m.handleDindListKeys(msg)
-	case TopView:
-		return m.handleTopViewKeys(msg)
-	case StatsView:
-		return m.handleStatsViewKeys(msg)
-	case ComposeProjectListView:
-		return m.handleProjectListKeys(msg)
-	case DockerContainerListView:
-		return m.handleDockerListKeys(msg)
-	case ImageListView:
-		return m.handleImageListKeys(msg)
-	case NetworkListView:
-		return m.handleNetworkListKeys(msg)
-	case VolumeListView:
-		return m.handleVolumeListKeys(msg)
-	case FileBrowserView:
-		return m.handleFileBrowserKeys(msg)
-	case FileContentView:
-		return m.handleFileContentKeys(msg)
-	case InspectView:
-		return m.handleInspectKeys(msg)
-	case HelpView:
-		return m.handleHelpKeys(msg)
-	case CommandExecutionView:
-		return m.handleCommandExecutionKeys(msg)
-	default:
-		// TODO: support some key shortcuts like '1', '2', '3', '4', '5'.
-		return m, nil
-	}
+	return m.handleViewKeys(msg)
 }
 
-func (m *Model) handleComposeProcessListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	handler, ok := m.composeProcessListViewKeymap[msg.String()]
-	slog.Info(fmt.Sprintf("Key: %s", msg.String()),
-		slog.Bool("ok", ok),
-		slog.Any("handler", m.composeProcessListViewKeymap))
-	if ok {
-		return handler(msg)
+// handleViewKeys handles key presses for the current view using the generic keymap
+func (m *Model) handleViewKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// Special case for ComposeProcessListView logging
+	if m.currentView == ComposeProcessListView {
+		slog.Info(fmt.Sprintf("Key: %s", msg.String()),
+			slog.Bool("ok", m.composeProcessListViewKeymap != nil),
+			slog.Any("handler", m.composeProcessListViewKeymap))
 	}
-	return m, nil
-}
 
-func (m *Model) handleLogViewKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	handler, ok := m.logViewKeymap[msg.String()]
-	if ok {
-		return handler(msg)
-	}
-	return m, nil
-}
-
-func (m *Model) handleDindListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	handler, ok := m.dindListViewKeymap[msg.String()]
-	if ok {
-		return handler(msg)
+	keymap := m.GetViewKeymap(m.currentView)
+	if keymap != nil {
+		handler, ok := keymap[msg.String()]
+		if ok {
+			return handler(msg)
+		}
 	}
 	return m, nil
 }
@@ -451,78 +409,6 @@ func (m *Model) handleQuitConfirmation(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func (m *Model) handleTopViewKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	handler, ok := m.topViewKeymap[msg.String()]
-	if ok {
-		return handler(msg)
-	}
-	return m, nil
-}
-
-func (m *Model) handleStatsViewKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	handler, ok := m.statsViewKeymap[msg.String()]
-	if ok {
-		return handler(msg)
-	}
-	return m, nil
-}
-
-func (m *Model) handleProjectListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	handler, ok := m.composeProjectListViewKeymap[msg.String()]
-	if ok {
-		return handler(msg)
-	}
-	return m, nil
-}
-
-func (m *Model) handleDockerListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	handler, ok := m.dockerListViewKeymap[msg.String()]
-	if ok {
-		return handler(msg)
-	}
-	return m, nil
-}
-
-func (m *Model) handleImageListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	handler, ok := m.imageListViewKeymap[msg.String()]
-	if ok {
-		return handler(msg)
-	}
-	return m, nil
-}
-
-func (m *Model) handleNetworkListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	handler, ok := m.networkListViewKeymap[msg.String()]
-	if ok {
-		return handler(msg)
-	}
-	return m, nil
-}
-
-func (m *Model) handleVolumeListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	handler, ok := m.volumeListViewKeymap[msg.String()]
-	if ok {
-		return handler(msg)
-	}
-	return m, nil
-}
-
-func (m *Model) handleFileBrowserKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	handler, ok := m.fileBrowserKeymap[msg.String()]
-	if ok {
-		return handler(msg)
-	}
-	return m, nil
-}
-
-func (m *Model) handleFileContentKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	handler, ok := m.fileContentKeymap[msg.String()]
-	if ok {
-		return handler(msg)
-	}
-	return m, nil
-}
-
 func (m *Model) handleFilterMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// Check if ESC was pressed to clear filter
 	if msg.Type == tea.KeyEsc {
@@ -534,30 +420,6 @@ func (m *Model) handleFilterMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	perform := m.logViewModel.HandleKey(msg)
 	if perform {
 		m.logViewModel.performFilter()
-	}
-	return m, nil
-}
-
-func (m *Model) handleInspectKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	handler, ok := m.inspectViewKeymap[msg.String()]
-	if ok {
-		return handler(msg)
-	}
-	return m, nil
-}
-
-func (m *Model) handleHelpKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	handler, ok := m.helpViewKeymap[msg.String()]
-	if ok {
-		return handler(msg)
-	}
-	return m, nil
-}
-
-func (m *Model) handleCommandExecutionKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	handler, ok := m.commandExecKeymap[msg.String()]
-	if ok {
-		return handler(msg)
 	}
 	return m, nil
 }

--- a/internal/ui/update_test.go
+++ b/internal/ui/update_test.go
@@ -289,12 +289,12 @@ func TestHandleDindListKeys(t *testing.T) {
 	model.initializeKeyHandlers()
 
 	// Test navigation
-	newModel, _ := model.handleDindListKeys(tea.KeyMsg{Type: tea.KeyDown})
+	newModel, _ := model.handleViewKeys(tea.KeyMsg{Type: tea.KeyDown})
 	m := newModel.(*Model)
 	assert.Equal(t, 1, m.dindProcessListViewModel.selectedDindContainer)
 
 	// Test entering log view
-	newModel, cmd := m.handleDindListKeys(tea.KeyMsg{Type: tea.KeyEnter})
+	newModel, cmd := m.handleViewKeys(tea.KeyMsg{Type: tea.KeyEnter})
 	m = newModel.(*Model)
 	assert.Equal(t, LogView, m.currentView)
 	assert.Equal(t, "test-2", m.logViewModel.containerName)
@@ -305,7 +305,7 @@ func TestHandleDindListKeys(t *testing.T) {
 	// Test escape - add viewHistory for proper navigation
 	model.currentView = DindProcessListView
 	model.viewHistory = []ViewType{ComposeProcessListView}
-	newModel, _ = model.handleDindListKeys(tea.KeyMsg{Type: tea.KeyEsc})
+	newModel, _ = model.handleViewKeys(tea.KeyMsg{Type: tea.KeyEsc})
 	m = newModel.(*Model)
 	assert.Equal(t, ComposeProcessListView, m.currentView)
 }


### PR DESCRIPTION
## Summary
- Added GetViewKeymap method to Model struct to retrieve keymaps for any view
- Created generic handleViewKeys method to replace 15 individual handlers  
- Removed duplicate view-specific key handler methods
- Updated tests to use the new generic handler

## Changes
This PR consolidates all view-specific key handler methods into a single generic method, significantly reducing code duplication. The refactoring:

1. **Added GetViewKeymap method**: Maps ViewType to the corresponding keymap
2. **Created handleViewKeys method**: Generic method that uses GetViewKeymap to handle keys for any view
3. **Removed 15 individual methods**: Eliminated handleLogViewKeys, handleTopViewKeys, handleStatsViewKeys, etc.
4. **Updated tests**: Modified tests to use the new generic handler

## Benefits
- Reduces code duplication significantly (removed ~150 lines of repetitive code)
- Makes key handling logic more maintainable
- Centralizes view-to-keymap mapping in one place
- Maintains all existing functionality with cleaner code structure

## Test plan
- [x] All existing tests pass
- [x] Manual testing of key handling in all views
- [x] Verified that all view-specific keybindings still work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)