### PR TITLE
refactor: Use SwitchView method instead of direct currentView assignment

### DIFF
--- a/internal/ui/keyhandler_compose.go
+++ b/internal/ui/keyhandler_compose.go
@@ -13,7 +13,7 @@ func (m *Model) CmdComposeDown(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m *Model) CmdComposeLS(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	m.currentView = ComposeProjectListView
+	m.SwitchView(ComposeProjectListView)
 	m.loading = true
 	return m, loadProjects(m.dockerClient)
 }

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -202,7 +202,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.fileContentViewModel.contentPath = msg.path
 		m.fileContentViewModel.scrollY = 0
 		m.err = nil
-		m.currentView = FileContentView
+		m.SwitchView(FileContentView)
 		return m, nil
 
 	case executeCommandMsg:

--- a/internal/ui/view_compose_process_list.go
+++ b/internal/ui/view_compose_process_list.go
@@ -20,7 +20,7 @@ type ComposeProcessListViewModel struct {
 
 func (m *ComposeProcessListViewModel) Load(model *Model, project models.ComposeProject) tea.Cmd {
 	model.projectName = project.Name
-	model.currentView = ComposeProcessListView
+	model.SwitchView(ComposeProcessListView)
 	model.loading = true
 	return loadProcesses(model.dockerClient, model.projectName, m.showAll)
 }

--- a/internal/ui/view_image_list.go
+++ b/internal/ui/view_image_list.go
@@ -77,7 +77,7 @@ func (m *ImageListViewModel) render(model *Model, availableHeight int) string {
 
 // Show switches to the image list view
 func (m *ImageListViewModel) Show(model *Model) tea.Cmd {
-	model.currentView = ImageListView
+	model.SwitchView(ImageListView)
 	model.loading = true
 	return loadDockerImages(model.dockerClient, m.showAll)
 }

--- a/internal/ui/view_network_list.go
+++ b/internal/ui/view_network_list.go
@@ -51,7 +51,7 @@ func (m *NetworkListViewModel) render(availableHeight int) string {
 
 // Show switches to the network list view
 func (m *NetworkListViewModel) Show(model *Model) tea.Cmd {
-	model.currentView = NetworkListView
+	model.SwitchView(NetworkListView)
 	model.loading = true
 	return loadDockerNetworks(model.dockerClient)
 }

--- a/internal/ui/view_stats.go
+++ b/internal/ui/view_stats.go
@@ -82,7 +82,7 @@ func (m *StatsViewModel) render(model *Model, availableHeight int) string {
 
 // Show switches to the stats view
 func (m *StatsViewModel) Show(model *Model) tea.Cmd {
-	model.currentView = StatsView
+	model.SwitchView(StatsView)
 	model.loading = true
 	return loadStats(model.dockerClient)
 }

--- a/internal/ui/view_top.go
+++ b/internal/ui/view_top.go
@@ -37,7 +37,7 @@ func (m *TopViewModel) render(model *Model, availableHeight int) string {
 // Load switches to the top view and loads process info
 func (m *TopViewModel) Load(model *Model, projectName string, service string) tea.Cmd {
 	m.topService = service
-	model.currentView = TopView
+	model.SwitchView(TopView)
 	model.loading = true
 	return loadTop(model.dockerClient, projectName, service)
 }

--- a/internal/ui/view_volume_list.go
+++ b/internal/ui/view_volume_list.go
@@ -47,7 +47,7 @@ func (m *VolumeListViewModel) render(model *Model, availableHeight int) string {
 
 // Show switches to the volume list view
 func (m *VolumeListViewModel) Show(model *Model) tea.Cmd {
-	model.currentView = VolumeListView
+	model.SwitchView(VolumeListView)
 	model.loading = true
 	m.selectedDockerVolume = 0
 	m.dockerVolumes = []models.DockerVolume{}


### PR DESCRIPTION
## Summary
- Replaced direct `model.currentView =` assignments with `model.SwitchView()` calls
- Ensures proper view history tracking for back navigation

## Changes
Updated the following files to use `model.SwitchView()` instead of directly setting `model.currentView`:
- `view_top.go` - Load method
- `view_volume_list.go` - Show method  
- `view_stats.go` - Show method
- `view_network_list.go` - Show method
- `view_image_list.go` - Show method
- `view_compose_process_list.go` - Load method
- `keyhandler_compose.go` - CmdComposeLS method
- `update.go` - fileContentLoadedMsg handler

## Benefits
- Consistent view history tracking across all view transitions
- Proper back navigation behavior (Esc/q key)
- Prevents view history corruption from direct assignments
- Makes the codebase more maintainable by using a single method for view switching

## Test plan
- [x] All existing tests pass
- [x] Manual testing of view switching and back navigation
- [x] Verified view history is properly maintained

🤖 Generated with [Claude Code](https://claude.ai/code)