### PR TITLE
refactor: Remove dead findCommandForCurrentView function

### DIFF
--- a/internal/ui/command.go
+++ b/internal/ui/command.go
@@ -151,11 +151,6 @@ func (m *CommandViewModel) executeKeyHandlerCommand(model *Model, cmdName string
 
 	// Check if command is available in current view
 	if cmd.ViewMask != 0 && cmd.ViewMask != model.currentView {
-		// Try to find a similar command for the current view
-		currentViewCmd := model.findCommandForCurrentView(cmdName)
-		if currentViewCmd != nil {
-			return currentViewCmd.Handler(tea.KeyMsg{})
-		}
 		model.err = fmt.Errorf("command '%s' is not available in current view", cmdName)
 		return model, nil
 	}

--- a/internal/ui/command_registry.go
+++ b/internal/ui/command_registry.go
@@ -184,14 +184,6 @@ func getShortCommandName(methodName string) string {
 	return ""
 }
 
-// findCommandForCurrentView tries to find a similar command for the current view
-func (m *Model) findCommandForCurrentView(baseCmdName string) *CommandHandler {
-	// This function is no longer needed as we don't have view-specific
-	// command variants anymore. All commands are either global or
-	// properly scoped to their views.
-	return nil
-}
-
 // getAvailableCommands returns a list of commands available in the current view
 func (m *Model) getAvailableCommands() []string {
 	var commands []string

--- a/internal/ui/command_registry.go
+++ b/internal/ui/command_registry.go
@@ -186,27 +186,9 @@ func getShortCommandName(methodName string) string {
 
 // findCommandForCurrentView tries to find a similar command for the current view
 func (m *Model) findCommandForCurrentView(baseCmdName string) *CommandHandler {
-	// Common command patterns that might have view-specific variants
-	patterns := []string{
-		"select-up-",
-		"select-down-",
-		"refresh-",
-		"back-from-",
-		"show-",
-	}
-
-	for _, pattern := range patterns {
-		if strings.HasPrefix(baseCmdName, pattern) {
-			// Try to find a view-specific version
-			for cmdName, cmd := range commandRegistry {
-				if strings.HasPrefix(cmdName, pattern) &&
-					(cmd.ViewMask == 0 || cmd.ViewMask == m.currentView) {
-					return &cmd
-				}
-			}
-		}
-	}
-
+	// This function is no longer needed as we don't have view-specific
+	// command variants anymore. All commands are either global or
+	// properly scoped to their views.
 	return nil
 }
 

--- a/internal/ui/command_registry_test.go
+++ b/internal/ui/command_registry_test.go
@@ -16,7 +16,7 @@ func TestToKebabCase(t *testing.T) {
 	}{
 		{"SelectUpContainer", "select-up-container"},
 		{"ShowComposeLog", "show-compose-log"},
-		{"BackFromLogView", "back-from-log-view"},
+		{"CmdBack", "cmd-back"},
 		{"simple", "simple"},
 		{"ABC", "a-b-c"},
 		{"", ""},


### PR DESCRIPTION
## Summary
- Completely removed the dead findCommandForCurrentView function
- Removed its usage from executeKeyHandlerCommand
- Updated test to use CmdBack instead of non-existent BackFromLogView

## Why remove it entirely?
You were right to ask why I didn't remove it completely in the first iteration. The function was:
1. Just returning nil (doing nothing)
2. Searching for command patterns that no longer exist in the codebase
3. Adding unnecessary complexity to the command execution logic

## Changes
- Removed findCommandForCurrentView function from command_registry.go
- Simplified executeKeyHandlerCommand by removing the call to findCommandForCurrentView
- Updated toKebabCase test to use CmdBack instead of BackFromLogView

This removes ~15 lines of dead code and simplifies the command execution flow.

🤖 Generated with [Claude Code](https://claude.ai/code)