### PR TITLE
refactor: Remove global variables from command registry

### DIFF
--- a/internal/ui/command.go
+++ b/internal/ui/command.go
@@ -126,7 +126,7 @@ func (m *CommandViewModel) executeCommand(model *Model) (tea.Model, tea.Cmd) {
 			commands := model.getAvailableCommands()
 			helpText := "Available commands in current view:\n"
 			for _, cmd := range commands {
-				if handler, exists := commandRegistry[cmd]; exists {
+				if handler, exists := model.commandRegistry[cmd]; exists {
 					helpText += fmt.Sprintf("  :%s - %s\n", cmd, handler.Description)
 				}
 			}
@@ -143,7 +143,7 @@ func (m *CommandViewModel) executeCommand(model *Model) (tea.Model, tea.Cmd) {
 
 // executeKeyHandlerCommand executes a command by name
 func (m *CommandViewModel) executeKeyHandlerCommand(model *Model, cmdName string) (tea.Model, tea.Cmd) {
-	cmd, exists := commandRegistry[cmdName]
+	cmd, exists := model.commandRegistry[cmdName]
 	if !exists {
 		model.err = fmt.Errorf("unknown command: %s", cmdName)
 		return model, nil

--- a/internal/ui/command_registry_test.go
+++ b/internal/ui/command_registry_test.go
@@ -36,8 +36,8 @@ func TestCommandRegistry(t *testing.T) {
 	model.initializeKeyHandlers()
 
 	// Test that command registry is populated
-	assert.NotNil(t, commandRegistry)
-	assert.Greater(t, len(commandRegistry), 0)
+	assert.NotNil(t, model.commandRegistry)
+	assert.Greater(t, len(model.commandRegistry), 0)
 
 	// Test that some common commands exist
 	commonCommands := []string{
@@ -51,7 +51,7 @@ func TestCommandRegistry(t *testing.T) {
 
 	for _, cmd := range commonCommands {
 		t.Run(cmd, func(t *testing.T) {
-			_, exists := commandRegistry[cmd]
+			_, exists := model.commandRegistry[cmd]
 			assert.True(t, exists, "Command %s should exist in registry", cmd)
 		})
 	}
@@ -65,8 +65,8 @@ func TestCommandRegistry(t *testing.T) {
 
 	for alias, target := range aliases {
 		t.Run("alias_"+alias, func(t *testing.T) {
-			aliasCmd, aliasExists := commandRegistry[alias]
-			targetCmd, targetExists := commandRegistry[target]
+			aliasCmd, aliasExists := model.commandRegistry[alias]
+			targetCmd, targetExists := model.commandRegistry[target]
 
 			assert.True(t, aliasExists, "Alias %s should exist", alias)
 			assert.True(t, targetExists, "Target %s should exist", target)
@@ -118,10 +118,10 @@ func TestExecuteKeyHandlerCommand(t *testing.T) {
 		testModel.composeProcessListViewModel.selectedContainer = 0
 
 		// Check that "down" command exists and what handler it has
-		if cmd, exists := commandRegistry["down"]; exists {
+		if cmd, exists := testModel.commandRegistry["down"]; exists {
 			t.Logf("Found 'down' command with description: %s, ViewMask: %v", cmd.Description, cmd.ViewMask)
 			// List all commands that have "down" in their name
-			for name, regCmd := range commandRegistry {
+			for name, regCmd := range testModel.commandRegistry {
 				if strings.Contains(name, "down") {
 					t.Logf("Command '%s' has ViewMask: %v", name, regCmd.ViewMask)
 				}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -146,6 +146,10 @@ type Model struct {
 	commandViewModel CommandViewModel
 
 	quitConfirmation bool
+
+	// Command registry - stores all available commands
+	commandRegistry  map[string]CommandHandler
+	handlerToCommand map[uintptr]string
 }
 
 // NewModel creates a new model with initial state

--- a/internal/ui/view_help.go
+++ b/internal/ui/view_help.go
@@ -36,7 +36,7 @@ func (m *HelpViewModel) render(model *Model, availableHeight int) string {
 				}
 
 				// Get command name for this handler
-				cmdName := getCommandForHandler(config.KeyHandler)
+				cmdName := model.getCommandForHandler(config.KeyHandler)
 				if cmdName != "" {
 					cmdName = ":" + cmdName
 				}
@@ -59,7 +59,7 @@ func (m *HelpViewModel) render(model *Model, availableHeight int) string {
 				}
 
 				// Get command name for this handler
-				cmdName := getCommandForHandler(config.KeyHandler)
+				cmdName := model.getCommandForHandler(config.KeyHandler)
 				if cmdName != "" {
 					cmdName = ":" + cmdName
 				}


### PR DESCRIPTION
## Summary
- Eliminated global state from command_registry.go by moving commandRegistry and handlerToCommand into Model struct
- Made getCommandForHandler a method on Model for better encapsulation
- Updated all references throughout the codebase to use model.commandRegistry

This refactoring improves testability and removes global state, following best practices for code organization.

## Test plan
- [x] Run `make fmt` to ensure code formatting
- [x] Run `make test` to ensure all tests pass
- [x] Verify command registry still works properly in the application

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>