### PR TITLE
refactor: Move projectName from Model to view models

### DIFF
--- a/internal/ui/command_registry_test.go
+++ b/internal/ui/command_registry_test.go
@@ -69,14 +69,14 @@ func TestExecuteKeyHandlerCommand(t *testing.T) {
 
 	// Test executing a navigation command
 	t.Run("down", func(t *testing.T) {
-		newModel, _ := model.commandViewModel.executeKeyHandlerCommand(&model, "down")
+		newModel, _ := model.commandViewModel.executeKeyHandlerCommand(model, "down")
 		m := newModel.(*Model)
 		assert.Equal(t, 2, m.composeProcessListViewModel.selectedContainer)
 	})
 
 	// Test executing an unknown command
 	t.Run("unknown-command", func(t *testing.T) {
-		newModel, _ := model.commandViewModel.executeKeyHandlerCommand(&model, "unknown-command")
+		newModel, _ := model.commandViewModel.executeKeyHandlerCommand(model, "unknown-command")
 		m := newModel.(*Model)
 		assert.NotNil(t, m.err)
 		assert.Contains(t, m.err.Error(), "unknown command")
@@ -98,7 +98,7 @@ func TestExecuteKeyHandlerCommand(t *testing.T) {
 			testModel.composeProcessListViewModel.selectedContainer,
 			len(testModel.composeProcessListViewModel.composeContainers))
 
-		newModel, cmd := testModel.commandViewModel.executeKeyHandlerCommand(&testModel, "down")
+		newModel, cmd := testModel.commandViewModel.executeKeyHandlerCommand(testModel, "down")
 		m := newModel.(*Model)
 
 		t.Logf("After: selectedContainer=%d, cmd=%v",

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -104,9 +104,6 @@ type Model struct {
 	// Loading state
 	loading bool
 
-	// Command line options
-	projectName string // TODO: Make this a part of the model?
-
 	globalKeymap   map[string]KeyHandler
 	globalHandlers []KeyConfig
 
@@ -153,18 +150,23 @@ type Model struct {
 }
 
 // NewModel creates a new model with initial state
-func NewModel(initialView ViewType, projectName string) Model {
+func NewModel(initialView ViewType, projectName string) *Model {
 	client := docker.NewClient()
 
 	slog.Info("Creating new model",
 		slog.String("initial_view", initialView.String()))
 
-	return Model{
+	m := &Model{
 		currentView:  initialView,
 		dockerClient: client,
 		loading:      true,
-		projectName:  projectName,
 	}
+
+	// Initialize project name in the appropriate view models
+	m.composeProcessListViewModel.projectName = projectName
+	m.composeProjectListViewModel.projectName = projectName
+
+	return m
 }
 
 // Init returns an initial command for the application
@@ -186,7 +188,7 @@ func (m *Model) Init() tea.Cmd {
 		// Otherwise, try to load composeContainers first - if it fails due to a missing compose file,
 		// we'll switch to the project list view in the update
 		return tea.Batch(
-			loadComposeProcesses(m.dockerClient, m.projectName, m.dockerContainerListViewModel.showAll),
+			loadComposeProcesses(m.dockerClient, m.composeProcessListViewModel.projectName, m.dockerContainerListViewModel.showAll),
 			tea.WindowSize(),
 		)
 	}

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestNewModel(t *testing.T) {
-	model := NewModel(ComposeProcessListView, "")
-	m := &model
+	m := NewModel(ComposeProcessListView, "")
 
 	assert.Equal(t, ComposeProcessListView, m.currentView)
 	assert.NotNil(t, m.dockerClient)
@@ -21,8 +20,7 @@ func TestNewModel(t *testing.T) {
 }
 
 func TestModelInit(t *testing.T) {
-	model := NewModel(ComposeProcessListView, "")
-	m := &model
+	m := NewModel(ComposeProcessListView, "")
 	cmd := m.Init()
 
 	// Init should return a batch command
@@ -30,8 +28,7 @@ func TestModelInit(t *testing.T) {
 }
 
 func TestProcessesLoadedMsg(t *testing.T) {
-	model := NewModel(ComposeProcessListView, "")
-	m := &model
+	m := NewModel(ComposeProcessListView, "")
 
 	// Test successful load
 	containers := []models.ComposeContainer{
@@ -67,8 +64,7 @@ func TestProcessesLoadedMsg(t *testing.T) {
 }
 
 func TestWindowSizeMsg(t *testing.T) {
-	model := NewModel(ComposeProcessListView, "")
-	m := &model
+	m := NewModel(ComposeProcessListView, "")
 
 	msg := tea.WindowSizeMsg{
 		Width:  80,
@@ -84,8 +80,7 @@ func TestWindowSizeMsg(t *testing.T) {
 }
 
 func TestKeyNavigation(t *testing.T) {
-	model := NewModel(ComposeProcessListView, "")
-	m := &model
+	m := NewModel(ComposeProcessListView, "")
 	m.Init() // Initialize key handlers
 	m.loading = false
 	m.composeProcessListViewModel.composeContainers = []models.ComposeContainer{
@@ -125,8 +120,7 @@ func TestKeyNavigation(t *testing.T) {
 }
 
 func TestViewSwitching(t *testing.T) {
-	model := NewModel(ComposeProcessListView, "")
-	m := &model
+	m := NewModel(ComposeProcessListView, "")
 	m.Init() // Initialize key handlers
 	m.loading = false
 	m.composeProcessListViewModel.composeContainers = []models.ComposeContainer{
@@ -171,8 +165,7 @@ func TestViewSwitching(t *testing.T) {
 }
 
 func TestSearchMode(t *testing.T) {
-	model := NewModel(ComposeProcessListView, "")
-	m := &model
+	m := NewModel(ComposeProcessListView, "")
 	m.Init() // Initialize key handlers
 	m.currentView = LogView
 	m.logViewModel.logs = []string{"line 1", "line 2", "error occurred", "line 4"}
@@ -203,8 +196,7 @@ func TestSearchMode(t *testing.T) {
 }
 
 func TestErrorHandling(t *testing.T) {
-	model := NewModel(ComposeProcessListView, "")
-	m := &model
+	m := NewModel(ComposeProcessListView, "")
 
 	// Test error message
 	msg := errorMsg{err: assert.AnError}
@@ -244,8 +236,7 @@ func TestQuitBehavior(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			model := NewModel(ComposeProcessListView, "")
-			m := &model
+			m := NewModel(ComposeProcessListView, "")
 			m.initializeKeyHandlers() // Initialize key handlers to register global 'q' handler
 			m.currentView = tt.currentView
 			m.loading = false

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -220,7 +220,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		switch m.currentView {
 		case ComposeProcessListView:
-			return m, loadComposeProcesses(m.dockerClient, m.projectName, m.composeProcessListViewModel.showAll)
+			return m, loadComposeProcesses(m.dockerClient, m.composeProcessListViewModel.projectName, m.composeProcessListViewModel.showAll)
 		case DindProcessListView:
 			return m, loadDindContainers(m.dockerClient, m.dindProcessListViewModel.currentDindContainerID)
 		case LogView:

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -90,8 +90,8 @@ func (m *Model) View() string {
 func (m *Model) viewTitle() string {
 	switch m.currentView {
 	case ComposeProcessListView:
-		if m.projectName != "" {
-			return fmt.Sprintf("Docker Compose: %s", m.projectName)
+		if m.composeProcessListViewModel.projectName != "" {
+			return fmt.Sprintf("Docker Compose: %s", m.composeProcessListViewModel.projectName)
 		}
 		return "Docker Compose"
 	case LogView:

--- a/internal/ui/view_command_execution.go
+++ b/internal/ui/view_command_execution.go
@@ -182,13 +182,13 @@ func (m *CommandExecutionViewModel) ExecuteCommand(model *Model, args ...string)
 	}
 }
 
-func (m *CommandExecutionViewModel) ExecuteComposeCommand(model *Model, operation string) tea.Cmd {
+func (m *CommandExecutionViewModel) ExecuteComposeCommand(model *Model, projectName string, operation string) tea.Cmd {
 	switch operation {
 	case "up":
-		args := []string{"compose", "-p", model.projectName, "up", "-d"}
+		args := []string{"compose", "-p", projectName, "up", "-d"}
 		return m.ExecuteCommand(model, args...)
 	case "down":
-		args := []string{"compose", "-p", model.projectName, "down"}
+		args := []string{"compose", "-p", projectName, "down"}
 		return m.ExecuteCommand(model, args...)
 	default:
 		return nil

--- a/internal/ui/view_compose_process_list.go
+++ b/internal/ui/view_compose_process_list.go
@@ -15,14 +15,15 @@ type ComposeProcessListViewModel struct {
 	// Process list state
 	composeContainers []models.ComposeContainer
 	selectedContainer int
-	showAll           bool // Toggle to show all composeContainers including stopped ones
+	showAll           bool   // Toggle to show all composeContainers including stopped ones
+	projectName       string // Current Docker Compose project name
 }
 
 func (m *ComposeProcessListViewModel) Load(model *Model, project models.ComposeProject) tea.Cmd {
-	model.projectName = project.Name
+	m.projectName = project.Name
 	model.SwitchView(ComposeProcessListView)
 	model.loading = true
-	return loadComposeProcesses(model.dockerClient, model.projectName, m.showAll)
+	return loadComposeProcesses(model.dockerClient, m.projectName, m.showAll)
 }
 
 func (m *ComposeProcessListViewModel) render(model *Model, availableHeight int) string {
@@ -131,13 +132,13 @@ func (m *ComposeProcessListViewModel) HandleLog(model *Model) tea.Cmd {
 func (m *ComposeProcessListViewModel) HandleToggleAll(model *Model) tea.Cmd {
 	m.showAll = !m.showAll
 	model.loading = true
-	return loadComposeProcesses(model.dockerClient, model.projectName, m.showAll)
+	return loadComposeProcesses(model.dockerClient, m.projectName, m.showAll)
 }
 
 func (m *ComposeProcessListViewModel) HandleTop(model *Model) tea.Cmd {
 	if m.selectedContainer < len(m.composeContainers) {
 		container := m.composeContainers[m.selectedContainer]
-		return model.topViewModel.Load(model, model.projectName, container.Service)
+		return model.topViewModel.Load(model, m.projectName, container.Service)
 	}
 	return nil
 }

--- a/internal/ui/view_compose_process_list_test.go
+++ b/internal/ui/view_compose_process_list_test.go
@@ -311,7 +311,7 @@ func TestComposeProcessListView_FullOutput(t *testing.T) {
 		}
 		m.width = 120
 		m.Height = 30
-		m.projectName = "test-project"
+		m.composeProcessListViewModel.projectName = "test-project"
 		m.loading = false
 		m.initializeKeyHandlers()
 

--- a/internal/ui/view_compose_project_list.go
+++ b/internal/ui/view_compose_project_list.go
@@ -14,6 +14,7 @@ type ComposeProjectListViewModel struct {
 	// Compose list state
 	projects        []models.ComposeProject
 	selectedProject int
+	projectName     string // Current selected project name
 }
 
 func (m *ComposeProjectListViewModel) render(model *Model, availableHeight int) string {

--- a/internal/ui/view_compose_project_list_test.go
+++ b/internal/ui/view_compose_project_list_test.go
@@ -173,8 +173,8 @@ func TestComposeProjectListViewModel_Operations(t *testing.T) {
 	t.Run("HandleSelectProject does nothing when no projects", func(t *testing.T) {
 		model := &Model{
 			currentView: ComposeProjectListView,
-			projectName: "old-project",
 		}
+		model.composeProcessListViewModel.projectName = "old-project"
 		vm := &ComposeProjectListViewModel{
 			projects:        []models.ComposeProject{},
 			selectedProject: 0,
@@ -183,7 +183,7 @@ func TestComposeProjectListViewModel_Operations(t *testing.T) {
 		cmd := vm.HandleSelectProject(model)
 
 		assert.Equal(t, ComposeProjectListView, model.currentView)
-		assert.Equal(t, "old-project", model.projectName, "Should not change project name")
+		assert.Equal(t, "old-project", model.composeProcessListViewModel.projectName, "Should not change project name")
 		assert.Nil(t, cmd)
 	})
 

--- a/internal/ui/view_top.go
+++ b/internal/ui/view_top.go
@@ -8,8 +8,9 @@ import (
 
 // TopViewModel manages the state and rendering of the process info view
 type TopViewModel struct {
-	topOutput  string
-	topService string
+	topOutput   string
+	topService  string
+	projectName string
 }
 
 // render renders the top view
@@ -37,6 +38,7 @@ func (m *TopViewModel) render(model *Model, availableHeight int) string {
 // Load switches to the top view and loads process info
 func (m *TopViewModel) Load(model *Model, projectName string, service string) tea.Cmd {
 	m.topService = service
+	m.projectName = projectName
 	model.SwitchView(TopView)
 	model.loading = true
 	return loadComposeTop(model.dockerClient, projectName, service)
@@ -45,7 +47,7 @@ func (m *TopViewModel) Load(model *Model, projectName string, service string) te
 // HandleRefresh reloads the process info
 func (m *TopViewModel) HandleRefresh(model *Model) tea.Cmd {
 	model.loading = true
-	return loadComposeTop(model.dockerClient, model.projectName, m.topService)
+	return loadComposeTop(model.dockerClient, m.projectName, m.topService)
 }
 
 // HandleBack returns to the compose process list view

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func main() {
 	m := ui.NewModel(initialView, "")
 
 	// Create the program
-	p := tea.NewProgram(&m, tea.WithAltScreen())
+	p := tea.NewProgram(m, tea.WithAltScreen())
 
 	// Run the program
 	if _, err := p.Run(); err != nil {


### PR DESCRIPTION
## Summary
- Moved `projectName` field from global `Model` struct to specific view models that need it
- Resolved the TODO comment in model.go about making projectName part of view models
- Changed `NewModel` to return `*Model` to fix sync.Mutex copy issue

## Changes
- Added `projectName` field to `ComposeProjectListViewModel` 
- Added `projectName` field to `ComposeProcessListViewModel`
- Added `projectName` field to `TopViewModel`
- Removed `projectName` from global `Model` struct
- Updated all references to use view model's `projectName` instead of global one
- Updated `ExecuteComposeCommand` to accept `projectName` parameter
- Fixed `NewModel` to return pointer to avoid copying sync.Mutex
- Updated tests to handle the new structure

## Test plan
- [x] All existing tests pass
- [x] Linting passes
- [x] Manual testing of projectName usage in different views

This change improves encapsulation by keeping project-specific state within the appropriate view models rather than the global Model struct, making the code more maintainable and clearer in terms of which components need access to project information.

🤖 Generated with [Claude Code](https://claude.ai/code)