### PR TITLE
feat: Add confirmation dialogs for aggressive Docker commands

### DIFF
--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -275,6 +275,21 @@ func (m *Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleQuitConfirmation(msg)
 	}
 
+	// Handle command execution confirmation dialog
+	if m.currentView == CommandExecutionView && m.commandExecutionViewModel.pendingConfirmation {
+		switch msg.String() {
+		case "y", "Y":
+			cmd := m.commandExecutionViewModel.HandleConfirmation(m, true)
+			return m, cmd
+		case "n", "N", "esc":
+			cmd := m.commandExecutionViewModel.HandleConfirmation(m, false)
+			return m, cmd
+		default:
+			// Ignore other keys during confirmation
+			return m, nil
+		}
+	}
+
 	// Handle search mode
 	if m.currentView == LogView && m.logViewModel.searchMode {
 		return m.handleSearchMode(msg, &m.logViewModel.SearchViewModel)

--- a/internal/ui/view_command_execution.go
+++ b/internal/ui/view_command_execution.go
@@ -14,18 +14,26 @@ import (
 )
 
 type CommandExecutionViewModel struct {
-	cmd       *exec.Cmd
-	output    []string
-	scrollY   int
-	done      bool
-	exitCode  int
-	cmdString string
-	reader    *bufio.Reader
+	cmd                 *exec.Cmd
+	output              []string
+	scrollY             int
+	done                bool
+	exitCode            int
+	cmdString           string
+	reader              *bufio.Reader
+	pendingConfirmation bool
+	pendingArgs         []string
+	confirmationTarget  string // e.g., "container nginx" or "service web"
 }
 
 func (m *CommandExecutionViewModel) render(model *Model) string {
 	if model.width == 0 || model.Height == 0 {
 		return "Loading..."
+	}
+
+	// Show confirmation dialog if pending
+	if m.pendingConfirmation {
+		return m.renderConfirmationDialog(model)
 	}
 
 	// Create viewport
@@ -156,6 +164,14 @@ func (m *CommandExecutionViewModel) ExecuteCommand(model *Model, args ...string)
 	m.scrollY = 0
 	m.done = false
 
+	// Check if this is an aggressive command that needs confirmation
+	if m.needsConfirmation(args) {
+		m.pendingConfirmation = true
+		m.pendingArgs = args
+		m.confirmationTarget = m.getConfirmationTarget(args)
+		return nil
+	}
+
 	return func() tea.Msg {
 		m.cmdString = fmt.Sprintf("docker %s", strings.Join(args, " "))
 
@@ -245,4 +261,242 @@ func streamCommandFromReader(m *CommandExecutionViewModel) tea.Cmd {
 		line = strings.TrimRight(line, "\n\r")
 		return commandExecOutputMsg{line: line}
 	}
+}
+
+// needsConfirmation checks if a command is aggressive and needs user confirmation
+func (m *CommandExecutionViewModel) needsConfirmation(args []string) bool {
+	if len(args) == 0 {
+		return false
+	}
+
+	// List of aggressive commands that need confirmation
+	aggressiveCommands := map[string]bool{
+		"stop":    true,
+		"start":   true,
+		"restart": true,
+		"kill":    true,
+		"pause":   true,
+		"unpause": true,
+		"rm":      true,
+		"rmi":     true,
+	}
+
+	// Check the first argument (the docker command)
+	if len(args) > 0 {
+		if aggressive, exists := aggressiveCommands[args[0]]; exists && aggressive {
+			return true
+		}
+	}
+
+	// Check for compose commands
+	if len(args) >= 2 && args[0] == "compose" {
+		for i, arg := range args {
+			if arg == "down" || arg == "stop" || arg == "restart" || arg == "kill" || arg == "rm" {
+				return true
+			}
+			// Check for service-specific commands like "compose restart service_name"
+			if i > 0 && (args[i-1] == "restart" || args[i-1] == "stop" || args[i-1] == "kill" || args[i-1] == "rm") {
+				return true
+			}
+		}
+	}
+
+	// Check for network/volume removal
+	if len(args) >= 2 && (args[0] == "network" || args[0] == "volume") && args[1] == "rm" {
+		return true
+	}
+
+	return false
+}
+
+// getConfirmationTarget extracts a human-readable target from the command args
+func (m *CommandExecutionViewModel) getConfirmationTarget(args []string) string {
+	if len(args) == 0 {
+		return "unknown"
+	}
+
+	// For compose commands
+	if len(args) >= 2 && args[0] == "compose" {
+		// Find the project name
+		projectName := ""
+		for i, arg := range args {
+			if arg == "-p" && i+1 < len(args) {
+				projectName = args[i+1]
+				break
+			}
+		}
+		if projectName != "" {
+			return fmt.Sprintf("project '%s'", projectName)
+		}
+		return "compose services"
+	}
+
+	// For network/volume commands
+	if len(args) >= 3 && (args[0] == "network" || args[0] == "volume") {
+		return fmt.Sprintf("%s '%s'", args[0], args[2])
+	}
+
+	// For image commands
+	if len(args) >= 2 && args[0] == "rmi" {
+		return fmt.Sprintf("image '%s'", args[len(args)-1])
+	}
+
+	// For direct container commands (e.g., "stop container_id")
+	if len(args) >= 2 {
+		// Try to extract container name or ID
+		containerID := args[len(args)-1]
+		if len(containerID) > 12 {
+			// Likely a container ID, truncate for display
+			containerID = containerID[:12]
+		}
+		return fmt.Sprintf("container %s", containerID)
+	}
+
+	return strings.Join(args, " ")
+}
+
+// renderConfirmationDialog renders the confirmation prompt
+func (m *CommandExecutionViewModel) renderConfirmationDialog(model *Model) string {
+	var content strings.Builder
+
+	// Center the dialog
+	padding := (model.Height - 10) / 2
+	for i := 0; i < padding; i++ {
+		content.WriteString("\n")
+	}
+
+	// Dialog box
+	warningStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("11")).
+		Bold(true)
+
+	questionStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("15"))
+
+	targetStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("14")).
+		Bold(true)
+
+	instructionStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("8"))
+
+	// Build the confirmation message
+	content.WriteString(lipgloss.NewStyle().Width(model.width).Align(lipgloss.Center).Render(
+		warningStyle.Render("⚠ WARNING"),
+	))
+	content.WriteString("\n\n")
+
+	// Parse the command for display
+	commandDisplay := m.getCommandDisplay(m.pendingArgs)
+	content.WriteString(lipgloss.NewStyle().Width(model.width).Align(lipgloss.Center).Render(
+		questionStyle.Render(fmt.Sprintf("Are you sure you want to %s", commandDisplay)),
+	))
+	content.WriteString("\n")
+	content.WriteString(lipgloss.NewStyle().Width(model.width).Align(lipgloss.Center).Render(
+		targetStyle.Render(m.confirmationTarget),
+	))
+	content.WriteString("\n\n")
+	content.WriteString(lipgloss.NewStyle().Width(model.width).Align(lipgloss.Center).Render(
+		instructionStyle.Render("Press 'y' to confirm, 'n' to cancel"),
+	))
+
+	return content.String()
+}
+
+// getCommandDisplay returns a human-readable command description
+func (m *CommandExecutionViewModel) getCommandDisplay(args []string) string {
+	if len(args) == 0 {
+		return "execute command"
+	}
+
+	// Map Docker commands to human-readable descriptions
+	commandDescriptions := map[string]string{
+		"stop":    "stop",
+		"start":   "start",
+		"restart": "restart",
+		"kill":    "forcefully stop",
+		"pause":   "pause",
+		"unpause": "unpause",
+		"rm":      "remove",
+		"rmi":     "remove image",
+	}
+
+	// For direct Docker commands
+	if desc, exists := commandDescriptions[args[0]]; exists {
+		return desc
+	}
+
+	// For compose commands
+	if len(args) >= 2 && args[0] == "compose" {
+		for _, arg := range args {
+			if desc, exists := commandDescriptions[arg]; exists {
+				return desc
+			}
+			if arg == "down" {
+				return "stop and remove all services in"
+			}
+			if arg == "up" {
+				return "start all services in"
+			}
+		}
+	}
+
+	// For network/volume commands
+	if len(args) >= 2 {
+		if args[0] == "network" && args[1] == "rm" {
+			return "remove network"
+		}
+		if args[0] == "volume" && args[1] == "rm" {
+			return "remove volume"
+		}
+	}
+
+	return args[0]
+}
+
+// HandleConfirmation processes user's confirmation response
+func (m *CommandExecutionViewModel) HandleConfirmation(model *Model, confirm bool) tea.Cmd {
+	if !m.pendingConfirmation {
+		return nil
+	}
+
+	if confirm {
+		// User confirmed, execute the command
+		m.pendingConfirmation = false
+		args := m.pendingArgs
+		m.pendingArgs = nil
+		m.confirmationTarget = ""
+
+		return func() tea.Msg {
+			m.cmdString = fmt.Sprintf("docker %s", strings.Join(args, " "))
+
+			// Create the command based on operation
+			cmd := exec.Command("docker", args...)
+
+			// Create pipes for stdout and stderr
+			stdout, err := cmd.StdoutPipe()
+			if err != nil {
+				return errorMsg{err: fmt.Errorf("failed to create stdout pipe: %w", err)}
+			}
+			stderr, err := cmd.StderrPipe()
+			if err != nil {
+				return errorMsg{err: fmt.Errorf("failed to create stderr pipe: %w", err)}
+			}
+
+			// Start the command
+			if err := cmd.Start(); err != nil {
+				return errorMsg{err: fmt.Errorf("failed to start command: %w", err)}
+			}
+
+			// Store the command reference and output channel
+			return commandExecStartedMsg{cmd: cmd, stdout: stdout, stderr: stderr}
+		}
+	}
+
+	// User cancelled, go back to previous view
+	m.pendingConfirmation = false
+	m.pendingArgs = nil
+	m.confirmationTarget = ""
+	model.SwitchToPreviousView()
+	return nil
 }

--- a/internal/ui/view_command_execution_test.go
+++ b/internal/ui/view_command_execution_test.go
@@ -1,0 +1,316 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommandExecutionViewModel_NeedsConfirmation(t *testing.T) {
+	vm := &CommandExecutionViewModel{}
+
+	tests := []struct {
+		name     string
+		args     []string
+		expected bool
+	}{
+		{
+			name:     "stop command needs confirmation",
+			args:     []string{"stop", "container_id"},
+			expected: true,
+		},
+		{
+			name:     "start command needs confirmation",
+			args:     []string{"start", "container_id"},
+			expected: true,
+		},
+		{
+			name:     "restart command needs confirmation",
+			args:     []string{"restart", "container_id"},
+			expected: true,
+		},
+		{
+			name:     "kill command needs confirmation",
+			args:     []string{"kill", "container_id"},
+			expected: true,
+		},
+		{
+			name:     "pause command needs confirmation",
+			args:     []string{"pause", "container_id"},
+			expected: true,
+		},
+		{
+			name:     "unpause command needs confirmation",
+			args:     []string{"unpause", "container_id"},
+			expected: true,
+		},
+		{
+			name:     "rm command needs confirmation",
+			args:     []string{"rm", "container_id"},
+			expected: true,
+		},
+		{
+			name:     "rmi command needs confirmation",
+			args:     []string{"rmi", "image_id"},
+			expected: true,
+		},
+		{
+			name:     "compose down needs confirmation",
+			args:     []string{"compose", "-p", "project", "down"},
+			expected: true,
+		},
+		{
+			name:     "compose stop needs confirmation",
+			args:     []string{"compose", "-p", "project", "stop"},
+			expected: true,
+		},
+		{
+			name:     "compose restart needs confirmation",
+			args:     []string{"compose", "-p", "project", "restart", "service"},
+			expected: true,
+		},
+		{
+			name:     "network rm needs confirmation",
+			args:     []string{"network", "rm", "network_name"},
+			expected: true,
+		},
+		{
+			name:     "volume rm needs confirmation",
+			args:     []string{"volume", "rm", "volume_name"},
+			expected: true,
+		},
+		{
+			name:     "logs command does not need confirmation",
+			args:     []string{"logs", "container_id"},
+			expected: false,
+		},
+		{
+			name:     "ps command does not need confirmation",
+			args:     []string{"ps"},
+			expected: false,
+		},
+		{
+			name:     "inspect command does not need confirmation",
+			args:     []string{"inspect", "container_id"},
+			expected: false,
+		},
+		{
+			name:     "exec command does not need confirmation",
+			args:     []string{"exec", "-it", "container_id", "/bin/sh"},
+			expected: false,
+		},
+		{
+			name:     "compose up does not need confirmation",
+			args:     []string{"compose", "-p", "project", "up", "-d"},
+			expected: false,
+		},
+		{
+			name:     "empty args does not need confirmation",
+			args:     []string{},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := vm.needsConfirmation(tt.args)
+			assert.Equal(t, tt.expected, result, "needsConfirmation(%v) should return %v", tt.args, tt.expected)
+		})
+	}
+}
+
+func TestCommandExecutionViewModel_GetConfirmationTarget(t *testing.T) {
+	vm := &CommandExecutionViewModel{}
+
+	tests := []struct {
+		name     string
+		args     []string
+		expected string
+	}{
+		{
+			name:     "container command with short ID",
+			args:     []string{"stop", "abc123"},
+			expected: "container abc123",
+		},
+		{
+			name:     "container command with long ID",
+			args:     []string{"stop", "abc123def456ghi789"},
+			expected: "container abc123def456",
+		},
+		{
+			name:     "compose command with project name",
+			args:     []string{"compose", "-p", "myproject", "down"},
+			expected: "project 'myproject'",
+		},
+		{
+			name:     "compose command without project name",
+			args:     []string{"compose", "down"},
+			expected: "compose services",
+		},
+		{
+			name:     "network removal",
+			args:     []string{"network", "rm", "mynetwork"},
+			expected: "network 'mynetwork'",
+		},
+		{
+			name:     "volume removal",
+			args:     []string{"volume", "rm", "myvolume"},
+			expected: "volume 'myvolume'",
+		},
+		{
+			name:     "image removal",
+			args:     []string{"rmi", "nginx:latest"},
+			expected: "image 'nginx:latest'",
+		},
+		{
+			name:     "empty args",
+			args:     []string{},
+			expected: "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := vm.getConfirmationTarget(tt.args)
+			assert.Equal(t, tt.expected, result, "getConfirmationTarget(%v) should return %v", tt.args, tt.expected)
+		})
+	}
+}
+
+func TestCommandExecutionViewModel_GetCommandDisplay(t *testing.T) {
+	vm := &CommandExecutionViewModel{}
+
+	tests := []struct {
+		name     string
+		args     []string
+		expected string
+	}{
+		{
+			name:     "stop command",
+			args:     []string{"stop", "container_id"},
+			expected: "stop",
+		},
+		{
+			name:     "kill command",
+			args:     []string{"kill", "container_id"},
+			expected: "forcefully stop",
+		},
+		{
+			name:     "rm command",
+			args:     []string{"rm", "container_id"},
+			expected: "remove",
+		},
+		{
+			name:     "compose down",
+			args:     []string{"compose", "-p", "project", "down"},
+			expected: "stop and remove all services in",
+		},
+		{
+			name:     "compose up",
+			args:     []string{"compose", "-p", "project", "up", "-d"},
+			expected: "start all services in",
+		},
+		{
+			name:     "network rm",
+			args:     []string{"network", "rm", "network_name"},
+			expected: "remove network",
+		},
+		{
+			name:     "volume rm",
+			args:     []string{"volume", "rm", "volume_name"},
+			expected: "remove volume",
+		},
+		{
+			name:     "empty args",
+			args:     []string{},
+			expected: "execute command",
+		},
+		{
+			name:     "unknown command",
+			args:     []string{"unknown", "arg"},
+			expected: "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := vm.getCommandDisplay(tt.args)
+			assert.Equal(t, tt.expected, result, "getCommandDisplay(%v) should return %v", tt.args, tt.expected)
+		})
+	}
+}
+
+func TestCommandExecutionViewModel_HandleConfirmation(t *testing.T) {
+	t.Run("confirm executes command", func(t *testing.T) {
+		model := &Model{
+			currentView: CommandExecutionView,
+		}
+		vm := &CommandExecutionViewModel{
+			pendingConfirmation: true,
+			pendingArgs:         []string{"stop", "container_id"},
+			confirmationTarget:  "container container_id",
+		}
+		model.commandExecutionViewModel = *vm
+
+		cmd := vm.HandleConfirmation(model, true)
+
+		assert.NotNil(t, cmd)
+		assert.False(t, vm.pendingConfirmation)
+		assert.Nil(t, vm.pendingArgs)
+		assert.Empty(t, vm.confirmationTarget)
+	})
+
+	t.Run("cancel returns to previous view", func(t *testing.T) {
+		model := &Model{
+			currentView: CommandExecutionView,
+			viewHistory: []ViewType{ComposeProcessListView},
+		}
+		vm := &CommandExecutionViewModel{
+			pendingConfirmation: true,
+			pendingArgs:         []string{"stop", "container_id"},
+			confirmationTarget:  "container container_id",
+		}
+		model.commandExecutionViewModel = *vm
+
+		cmd := vm.HandleConfirmation(model, false)
+
+		assert.Nil(t, cmd)
+		assert.False(t, vm.pendingConfirmation)
+		assert.Nil(t, vm.pendingArgs)
+		assert.Empty(t, vm.confirmationTarget)
+		assert.Equal(t, ComposeProcessListView, model.currentView)
+	})
+
+	t.Run("no-op when no pending confirmation", func(t *testing.T) {
+		model := &Model{
+			currentView: CommandExecutionView,
+		}
+		vm := &CommandExecutionViewModel{
+			pendingConfirmation: false,
+		}
+
+		cmd := vm.HandleConfirmation(model, true)
+
+		assert.Nil(t, cmd)
+	})
+}
+
+func TestCommandExecutionViewModel_RenderConfirmationDialog(t *testing.T) {
+	model := &Model{
+		width:  80,
+		Height: 24,
+	}
+	vm := &CommandExecutionViewModel{
+		pendingConfirmation: true,
+		pendingArgs:         []string{"stop", "container_id"},
+		confirmationTarget:  "container nginx",
+	}
+
+	result := vm.renderConfirmationDialog(model)
+
+	// Check that the dialog contains key elements
+	assert.Contains(t, result, "WARNING")
+	assert.Contains(t, result, "Are you sure you want to stop")
+	assert.Contains(t, result, "container nginx")
+	assert.Contains(t, result, "Press 'y' to confirm, 'n' to cancel")
+}

--- a/internal/ui/view_image_list_test.go
+++ b/internal/ui/view_image_list_test.go
@@ -191,19 +191,26 @@ func TestImageListViewModel_Operations(t *testing.T) {
 		model := &Model{
 			loading:                   false,
 			commandExecutionViewModel: CommandExecutionViewModel{},
+			currentView:               ImageListView,
 		}
 		vm := &ImageListViewModel{
 			dockerImages: []models.DockerImage{
-				{ID: "image1"},
-				{ID: "image2"},
+				{ID: "image1", Repository: "test", Tag: "latest"},
+				{ID: "image2", Repository: "test2", Tag: "v1"},
 			},
 			selectedDockerImage: 1,
 		}
 
 		cmd := vm.HandleDelete(model)
 
-		// Command execution doesn't set loading anymore, it switches view
-		assert.NotNil(t, cmd)
+		// HandleDelete now shows confirmation dialog, so returns nil
+		assert.Nil(t, cmd)
+		// Should switch to CommandExecutionView
+		assert.Equal(t, CommandExecutionView, model.currentView)
+		// Should set pending confirmation
+		assert.True(t, model.commandExecutionViewModel.pendingConfirmation)
+		// Should have the correct pending args
+		assert.Equal(t, []string{"rmi", "test2:v1"}, model.commandExecutionViewModel.pendingArgs)
 	})
 
 	t.Run("HandleDelete does nothing when no images", func(t *testing.T) {


### PR DESCRIPTION
## Summary
This PR adds confirmation dialogs for potentially destructive Docker operations to prevent accidental execution of disruptive commands.

## Changes
- Added confirmation prompts for aggressive operations:
  - Container operations: stop, start, restart, kill, pause, unpause, rm
  - Image operations: rmi (remove image)
  - Network/Volume operations: rm (remove)
  - Docker Compose operations: down, stop, restart, kill, rm
- Shows clear warning dialog with:
  - Command description (e.g., "forcefully stop")
  - Target specification (e.g., "container nginx")
  - Y/N confirmation prompt
- Comprehensive test coverage for all confirmation scenarios

## Test Plan
- [x] Run `make test` - all tests pass
- [x] Manual testing of confirmation dialogs for various commands
- [x] Verify that non-aggressive commands (logs, ps, inspect, etc.) don't show confirmations
- [x] Test cancellation returns to previous view
- [x] Test confirmation executes the command

## Screenshots
The confirmation dialog shows:
```
⚠ WARNING

Are you sure you want to stop
container nginx

Press 'y' to confirm, 'n' to cancel
```

🤖 Generated with [Claude Code](https://claude.ai/code)