### PR TITLE
Add 'top' command support to all process views

### DIFF
--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -9,6 +9,8 @@ type Container interface {
 
 	// Title returns a title for the container, used in UI
 	Title() string
+
+	Top() ([]byte, error)
 }
 
 type ContainerImpl struct {
@@ -46,6 +48,10 @@ func (c ContainerImpl) Title() string {
 	return c.title
 }
 
+func (c ContainerImpl) Top() ([]byte, error) {
+	return c.client.ExecuteCaptured("top", c.containerID)
+}
+
 type DindContainerImpl struct {
 	client            *Client
 	hostContainerName string
@@ -81,4 +87,8 @@ func (c DindContainerImpl) GetName() string {
 
 func (c DindContainerImpl) Title() string {
 	return fmt.Sprintf("DinD: %s (%s)", c.hostContainerID, c.name)
+}
+
+func (c DindContainerImpl) Top() ([]byte, error) {
+	return c.client.ExecuteCaptured("exec", c.hostContainerID, "docker", "top", c.containerID)
 }

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -6,16 +6,20 @@ type Container interface {
 	Inspect() ([]byte, error)
 	GetName() string
 	GetContainerID() string
+
+	// Title returns a title for the container, used in UI
+	Title() string
 }
 
 type ContainerImpl struct {
 	containerID string
 	client      *Client
 	name        string
+	title       string
 }
 
-func NewContainer(client *Client, containerID string, name string) Container {
-	return ContainerImpl{client: client, containerID: containerID, name: name}
+func NewContainer(client *Client, containerID string, name string, title string) Container {
+	return ContainerImpl{client: client, containerID: containerID, name: name, title: title}
 }
 
 func (c ContainerImpl) ContainerID() string {
@@ -38,15 +42,25 @@ func (c ContainerImpl) GetContainerID() string {
 	return c.containerID
 }
 
-type DindContainerImpl struct {
-	client          *Client
-	hostContainerID string
-	containerID     string
-	name            string
+func (c ContainerImpl) Title() string {
+	return c.title
 }
 
-func NewDindContainer(client *Client, hostContainerID, containerID string, name string) Container {
-	return DindContainerImpl{client: client, hostContainerID: hostContainerID, containerID: containerID, name: name}
+type DindContainerImpl struct {
+	client            *Client
+	hostContainerName string
+	hostContainerID   string
+	containerID       string
+	name              string
+}
+
+func NewDindContainer(client *Client, hostContainerID, hostContainerName, containerID, name string) Container {
+	return DindContainerImpl{
+		client:            client,
+		hostContainerID:   hostContainerID,
+		hostContainerName: hostContainerName,
+		containerID:       containerID,
+		name:              name}
 }
 
 func (c DindContainerImpl) GetContainerID() string {
@@ -63,4 +77,8 @@ func (c DindContainerImpl) Inspect() ([]byte, error) {
 
 func (c DindContainerImpl) GetName() string {
 	return c.name
+}
+
+func (c DindContainerImpl) Title() string {
+	return fmt.Sprintf("DinD: %s (%s)", c.hostContainerID, c.name)
 }

--- a/internal/ui/keyhandler_base.go
+++ b/internal/ui/keyhandler_base.go
@@ -1,6 +1,9 @@
 package ui
 
-import tea "github.com/charmbracelet/bubbletea"
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/tokuhirom/dcv/internal/docker"
+)
 
 // KeyHandler represents a function that handles a key press
 type KeyHandler func(msg tea.KeyMsg) (tea.Model, tea.Cmd)
@@ -10,4 +13,8 @@ type KeyConfig struct {
 	Keys        []string
 	Description string
 	KeyHandler  KeyHandler
+}
+
+type GetContainerAware interface {
+	GetContainer(model *Model) docker.Container
 }

--- a/internal/ui/keyhandler_base.go
+++ b/internal/ui/keyhandler_base.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	tea "github.com/charmbracelet/bubbletea"
+
 	"github.com/tokuhirom/dcv/internal/docker"
 )
 

--- a/internal/ui/keyhandler_compose.go
+++ b/internal/ui/keyhandler_compose.go
@@ -21,15 +21,6 @@ func (m *Model) CmdSelectProject(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 }
 
-func (m *Model) CmdTop(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	switch m.currentView {
-	case ComposeProcessListView:
-		return m, m.composeProcessListViewModel.HandleTop(m)
-	default:
-		return m, nil
-	}
-}
-
 func (m *Model) CmdStats(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, m.statsViewModel.Show(m)
 }

--- a/internal/ui/keyhandler_docker.go
+++ b/internal/ui/keyhandler_docker.go
@@ -143,9 +143,7 @@ func (m *Model) CmdTop(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	slog.Info("CmdTop, vm")
 	if containerAware, ok := vm.(GetContainerAware); ok {
-		slog.Info("CmdTop, aware")
 		container := containerAware.GetContainer(m)
 		if container == nil {
 			slog.Error("Failed to get selected container for top command")

--- a/internal/ui/keyhandler_docker.go
+++ b/internal/ui/keyhandler_docker.go
@@ -133,3 +133,16 @@ func (m *Model) CmdInspect(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 }
+
+func (m *Model) CmdTop(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch m.currentView {
+	case DindProcessListView:
+		return m, m.dindProcessListViewModel.HandleTop(m)
+	case DockerContainerListView:
+		return m, m.dockerContainerListViewModel.HandleTop(m)
+	case ComposeProcessListView:
+		return m, m.composeProcessListViewModel.HandleTop(m)
+	default:
+		return m, nil
+	}
+}

--- a/internal/ui/keymap.go
+++ b/internal/ui/keymap.go
@@ -18,6 +18,7 @@ func (m *Model) initializeKeyHandlers() {
 	}
 	m.globalKeymap = m.createKeymap(m.globalHandlers)
 
+	// TODO: support following commands in dind view
 	containerOperations := []KeyConfig{
 		{[]string{"f"}, "browse files", m.CmdFileBrowse},
 		{[]string{"!"}, "exec /bin/sh", m.CmdShell},
@@ -30,6 +31,7 @@ func (m *Model) initializeKeyHandlers() {
 		{[]string{"R"}, "restart", m.CmdRestart},
 		{[]string{"P"}, "pause/unpause", m.CmdPause},
 		{[]string{"D"}, "delete", m.CmdDelete},
+		{[]string{"t"}, "top", m.CmdTop},
 	}
 
 	// Docker Container List View
@@ -53,8 +55,6 @@ func (m *Model) initializeKeyHandlers() {
 		{[]string{"esc"}, "back", m.CmdBack},
 		{[]string{"?"}, "help", m.CmdHelp},
 
-		// TODO: move to containerOperations
-		{[]string{"t"}, "top", m.CmdTop},
 		// TODO: support compose stats
 
 		{[]string{"d"}, "entering DinD", m.CmdDind},
@@ -88,6 +88,8 @@ func (m *Model) initializeKeyHandlers() {
 
 		{[]string{"i"}, "inspect", m.CmdInspect},
 		// TODO: support file browser
+
+		{[]string{"t"}, "top", m.CmdTop},
 	}
 	m.dindListViewKeymap = m.createKeymap(m.dindListViewHandlers)
 

--- a/internal/ui/keymap.go
+++ b/internal/ui/keymap.go
@@ -89,6 +89,16 @@ func (m *Model) initializeKeyHandlers() {
 		{[]string{"i"}, "inspect", m.CmdInspect},
 		// TODO: support file browser
 
+		// TODO: support all containerOperations.
+		// TODO: {[]string{"f"}, "browse files", m.CmdFileBrowse},
+		// TODO: {[]string{"!"}, "exec /bin/sh", m.CmdShell},
+		// TODO: {[]string{"a"}, "toggle all", m.CmdToggleAll},
+		// TODO: {[]string{"K"}, "kill", m.CmdKill},
+		// TODO: {[]string{"S"}, "stop", m.CmdStop},
+		// TODO: {[]string{"U"}, "start", m.CmdStart},
+		// TODO: {[]string{"R"}, "restart", m.CmdRestart},
+		// TODO: {[]string{"P"}, "pause/unpause", m.CmdPause},
+		// TODO: {[]string{"D"}, "delete", m.CmdDelete},
 		{[]string{"t"}, "top", m.CmdTop},
 	}
 	m.dindListViewKeymap = m.createKeymap(m.dindListViewHandlers)

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -209,6 +209,45 @@ func (m *Model) SwitchToPreviousView() {
 	m.currentView = previousView
 }
 
+func (m *Model) GetCurrentViewModel() interface{} {
+	switch m.currentView {
+	case ComposeProcessListView:
+		return &m.composeProcessListViewModel
+	case LogView:
+		return &m.logViewModel
+	case DindProcessListView:
+		return &m.dindProcessListViewModel
+	case TopView:
+		return &m.topViewModel
+	case StatsView:
+		return &m.statsViewModel
+	case ComposeProjectListView:
+		return &m.composeProjectListViewModel
+	case DockerContainerListView:
+		return &m.dockerContainerListViewModel
+	case ImageListView:
+		return &m.imageListViewModel
+	case NetworkListView:
+		return &m.networkListViewModel
+	case VolumeListView:
+		return &m.volumeListViewModel
+	case FileBrowserView:
+		return &m.fileBrowserViewModel
+	case FileContentView:
+		return &m.fileContentViewModel
+	case InspectView:
+		return &m.inspectViewModel
+	case HelpView:
+		return &m.helpViewModel
+	case CommandExecutionView:
+		return &m.commandExecutionViewModel
+	default:
+		slog.Error("GetCurrentViewModel called with unknown view",
+			slog.String("view", m.currentView.String()))
+		return nil
+	}
+}
+
 // GetViewKeyHandlers returns the key handlers for the specified view
 func (m *Model) GetViewKeyHandlers(view ViewType) []KeyConfig {
 	switch view {

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -159,7 +159,7 @@ func TestViewSwitching(t *testing.T) {
 	m = newModel.(*Model)
 
 	assert.Equal(t, DindProcessListView, m.currentView)
-	assert.Equal(t, "dind-1", m.dindProcessListViewModel.currentDindHostName)
+	assert.Equal(t, "dind-1", m.dindProcessListViewModel.hostContainer.GetName())
 	assert.True(t, m.loading)
 	assert.NotNil(t, cmd)
 }

--- a/internal/ui/update_test.go
+++ b/internal/ui/update_test.go
@@ -6,6 +6,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
+
 	"github.com/tokuhirom/dcv/internal/docker"
 
 	"github.com/tokuhirom/dcv/internal/models"

--- a/internal/ui/update_test.go
+++ b/internal/ui/update_test.go
@@ -6,6 +6,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
+	"github.com/tokuhirom/dcv/internal/docker"
 
 	"github.com/tokuhirom/dcv/internal/models"
 )
@@ -91,7 +92,7 @@ func TestHandleKeyPress(t *testing.T) {
 			wantView:    DindProcessListView,
 			wantLoading: true,
 			checkFunc: func(t *testing.T, m *Model) {
-				assert.Equal(t, "dind-1", m.dindProcessListViewModel.currentDindHostName)
+				assert.Equal(t, "dind-1", m.dindProcessListViewModel.hostContainer.GetName())
 			},
 		},
 		{
@@ -277,7 +278,7 @@ func TestHandleDindListKeys(t *testing.T) {
 	model := Model{
 		currentView: DindProcessListView,
 		dindProcessListViewModel: DindProcessListViewModel{
-			currentDindHostName: "dind-1",
+			hostContainer: docker.NewDindContainer(docker.NewClient(), "dind-1", "dind-1", "dockerd"),
 			dindContainers: []models.DockerContainer{
 				{ID: "abc123", Names: "test-1"},
 				{ID: "def456", Names: "test-2"},
@@ -298,7 +299,7 @@ func TestHandleDindListKeys(t *testing.T) {
 	m = newModel.(*Model)
 	assert.Equal(t, LogView, m.currentView)
 	assert.Equal(t, "test-2", m.logViewModel.containerName)
-	assert.Equal(t, "dind-1", m.logViewModel.hostContainer)
+	assert.Equal(t, "dind-1", m.logViewModel.hostContainerName)
 	assert.True(t, m.logViewModel.isDindLog)
 	assert.NotNil(t, cmd)
 

--- a/internal/ui/update_test.go
+++ b/internal/ui/update_test.go
@@ -279,7 +279,7 @@ func TestHandleDindListKeys(t *testing.T) {
 	model := Model{
 		currentView: DindProcessListView,
 		dindProcessListViewModel: DindProcessListViewModel{
-			hostContainer: docker.NewDindContainer(docker.NewClient(), "dind-1", "dind-1", "dind-1", "dockerd"),
+			hostContainer: docker.NewDindContainer(docker.NewClient(), "dind-1", "dind-1", "dind-1", "dind-1"),
 			dindContainers: []models.DockerContainer{
 				{ID: "abc123", Names: "test-1"},
 				{ID: "def456", Names: "test-2"},

--- a/internal/ui/update_test.go
+++ b/internal/ui/update_test.go
@@ -278,7 +278,7 @@ func TestHandleDindListKeys(t *testing.T) {
 	model := Model{
 		currentView: DindProcessListView,
 		dindProcessListViewModel: DindProcessListViewModel{
-			hostContainer: docker.NewDindContainer(docker.NewClient(), "dind-1", "dind-1", "dockerd"),
+			hostContainer: docker.NewDindContainer(docker.NewClient(), "dind-1", "dind-1", "dind-1", "dockerd"),
 			dindContainers: []models.DockerContainer{
 				{ID: "abc123", Names: "test-1"},
 				{ID: "def456", Names: "test-2"},

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -153,7 +153,7 @@ func (m *Model) viewBody(availableHeight int) string {
 	case DindProcessListView:
 		return m.dindProcessListViewModel.render(availableHeight)
 	case TopView:
-		return m.topViewModel.render(m, availableHeight)
+		return m.topViewModel.render(availableHeight)
 	case StatsView:
 		return m.statsViewModel.render(m, availableHeight)
 	case ComposeProjectListView:

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -103,7 +103,7 @@ func (m *Model) viewTitle() string {
 	case DindProcessListView:
 		return m.dindProcessListViewModel.Title()
 	case TopView:
-		return fmt.Sprintf("Process Info: %s", m.topViewModel.topService)
+		return m.topViewModel.Title()
 	case StatsView:
 		return "Stats"
 	case ComposeProjectListView:

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -101,7 +101,7 @@ func (m *Model) viewTitle() string {
 	case LogView:
 		return m.logViewModel.Title()
 	case DindProcessListView:
-		return fmt.Sprintf("Docker in Docker: %s", m.dindProcessListViewModel.currentDindHostName)
+		return m.dindProcessListViewModel.Title()
 	case TopView:
 		return fmt.Sprintf("Process Info: %s", m.topViewModel.topService)
 	case StatsView:

--- a/internal/ui/view_compose_process_list.go
+++ b/internal/ui/view_compose_process_list.go
@@ -213,7 +213,8 @@ func (m *ComposeProcessListViewModel) HandleShell() tea.Cmd {
 func (m *ComposeProcessListViewModel) GetContainer(model *Model) docker.Container {
 	if m.selectedContainer < len(m.composeContainers) {
 		container := m.composeContainers[m.selectedContainer]
-		return docker.NewContainer(model.dockerClient, container.ID, container.Name)
+		return docker.NewContainer(model.dockerClient, container.ID, container.Name,
+			fmt.Sprintf("%s(project:%s)", container.Service, m.projectName))
 	}
 	return nil
 }

--- a/internal/ui/view_compose_process_list.go
+++ b/internal/ui/view_compose_process_list.go
@@ -149,17 +149,6 @@ func (m *ComposeProcessListViewModel) HandleToggleAll(model *Model) tea.Cmd {
 	return m.DoLoad(model)
 }
 
-func (m *ComposeProcessListViewModel) HandleTop(model *Model) tea.Cmd {
-	container := m.GetContainer(model)
-	if container == nil {
-		slog.Error("Failed to get selected container for top view",
-			slog.Any("error", fmt.Errorf("no container selected")))
-		return nil
-	}
-
-	return model.topViewModel.Load(model, container)
-}
-
 func (m *ComposeProcessListViewModel) HandleDindProcessList(model *Model) tea.Cmd {
 	container := m.GetContainer(model)
 	if container == nil {

--- a/internal/ui/view_compose_process_list.go
+++ b/internal/ui/view_compose_process_list.go
@@ -150,11 +150,14 @@ func (m *ComposeProcessListViewModel) HandleToggleAll(model *Model) tea.Cmd {
 }
 
 func (m *ComposeProcessListViewModel) HandleTop(model *Model) tea.Cmd {
-	if m.selectedContainer < len(m.composeContainers) {
-		container := m.composeContainers[m.selectedContainer]
-		return model.topViewModel.Load(model, m.projectName, container.Service)
+	container := m.GetContainer(model)
+	if container == nil {
+		slog.Error("Failed to get selected container for top view",
+			slog.Any("error", fmt.Errorf("no container selected")))
+		return nil
 	}
-	return nil
+
+	return model.topViewModel.Load(model, container)
 }
 
 func (m *ComposeProcessListViewModel) HandleDindProcessList(model *Model) tea.Cmd {

--- a/internal/ui/view_dind_process_list.go
+++ b/internal/ui/view_dind_process_list.go
@@ -15,10 +15,10 @@ import (
 
 // DindProcessListViewModel manages the state and rendering of the Docker-in-Docker process list view
 type DindProcessListViewModel struct {
-	dindContainers         []models.DockerContainer
-	selectedDindContainer  int
-	currentDindHostName    string // Container name (for display)
-	currentDindContainerID string // Service name (for docker compose exec)
+	dindContainers        []models.DockerContainer
+	selectedDindContainer int
+
+	hostContainer docker.Container
 }
 
 // render renders the dind process list view
@@ -92,8 +92,7 @@ func (m *DindProcessListViewModel) render(availableHeight int) string {
 
 // Load switches to the dind process list view and loads containers
 func (m *DindProcessListViewModel) Load(model *Model, hostContainer docker.Container) tea.Cmd {
-	m.currentDindHostName = hostContainer.GetName()
-	m.currentDindContainerID = hostContainer.GetContainerID()
+	m.hostContainer = hostContainer
 	model.SwitchView(DindProcessListView)
 	return m.DoLoad(model)
 }
@@ -102,7 +101,7 @@ func (m *DindProcessListViewModel) Load(model *Model, hostContainer docker.Conta
 func (m *DindProcessListViewModel) DoLoad(model *Model) tea.Cmd {
 	model.loading = true
 	return func() tea.Msg {
-		containers, err := model.dockerClient.Dind(m.currentDindContainerID).ListContainers()
+		containers, err := model.dockerClient.Dind(m.hostContainer.GetContainerID()).ListContainers()
 		return dindContainersLoadedMsg{
 			containers: containers,
 			err:        err,
@@ -133,7 +132,7 @@ func (m *DindProcessListViewModel) HandleLog(model *Model) tea.Cmd {
 	}
 
 	container := m.dindContainers[m.selectedDindContainer]
-	return model.logViewModel.StreamLogsDind(model, m.currentDindContainerID, container)
+	return model.logViewModel.StreamLogsDind(model, m.hostContainer.GetContainerID(), container)
 }
 
 // HandleBack returns to the compose process list view
@@ -153,7 +152,7 @@ func (m *DindProcessListViewModel) Loaded(containers []models.DockerContainer) {
 func (m *DindProcessListViewModel) GetContainer(model *Model) docker.Container {
 	if m.selectedDindContainer < len(m.dindContainers) {
 		container := m.dindContainers[m.selectedDindContainer]
-		return docker.NewDindContainer(model.dockerClient, m.currentDindHostName, container.ID, container.Names)
+		return docker.NewDindContainer(model.dockerClient, m.hostContainer.GetContainerID(), container.ID, container.Names)
 	}
 	return nil
 }
@@ -167,9 +166,13 @@ func (m *DindProcessListViewModel) HandleInspect(model *Model) tea.Cmd {
 	}
 
 	return model.inspectViewModel.Inspect(model,
-		fmt.Sprintf("DinD: %s (%s)", m.currentDindHostName, container.GetName()),
+		fmt.Sprintf("DinD: %s (%s)", m.hostContainer.GetName(), container.GetName()),
 		func() ([]byte, error) {
 			return container.Inspect()
 		},
 	)
+}
+
+func (m *DindProcessListViewModel) Title() string {
+	return fmt.Sprintf("Docker in Docker: %s", m.hostContainer.GetName())
 }

--- a/internal/ui/view_dind_process_list.go
+++ b/internal/ui/view_dind_process_list.go
@@ -152,7 +152,10 @@ func (m *DindProcessListViewModel) Loaded(containers []models.DockerContainer) {
 func (m *DindProcessListViewModel) GetContainer(model *Model) docker.Container {
 	if m.selectedDindContainer < len(m.dindContainers) {
 		container := m.dindContainers[m.selectedDindContainer]
-		return docker.NewDindContainer(model.dockerClient, m.hostContainer.GetContainerID(), container.ID, container.Names)
+		return docker.NewDindContainer(model.dockerClient,
+			m.hostContainer.GetContainerID(),
+			m.hostContainer.GetName(),
+			container.ID, container.Names)
 	}
 	return nil
 }

--- a/internal/ui/view_dind_process_list.go
+++ b/internal/ui/view_dind_process_list.go
@@ -179,13 +179,3 @@ func (m *DindProcessListViewModel) HandleInspect(model *Model) tea.Cmd {
 func (m *DindProcessListViewModel) Title() string {
 	return fmt.Sprintf("Docker in Docker: %s", m.hostContainer.GetName())
 }
-
-func (m *DindProcessListViewModel) HandleTop(model *Model) tea.Cmd {
-	container := m.GetContainer(model)
-	if container == nil {
-		slog.Error("Failed to get selected container for top view",
-			slog.Any("error", fmt.Errorf("no container selected")))
-		return nil
-	}
-	return model.topViewModel.Load(model, container)
-}

--- a/internal/ui/view_dind_process_list.go
+++ b/internal/ui/view_dind_process_list.go
@@ -179,3 +179,13 @@ func (m *DindProcessListViewModel) HandleInspect(model *Model) tea.Cmd {
 func (m *DindProcessListViewModel) Title() string {
 	return fmt.Sprintf("Docker in Docker: %s", m.hostContainer.GetName())
 }
+
+func (m *DindProcessListViewModel) HandleTop(model *Model) tea.Cmd {
+	container := m.GetContainer(model)
+	if container == nil {
+		slog.Error("Failed to get selected container for top view",
+			slog.Any("error", fmt.Errorf("no container selected")))
+		return nil
+	}
+	return model.topViewModel.Load(model, container)
+}

--- a/internal/ui/view_docker_container_list.go
+++ b/internal/ui/view_docker_container_list.go
@@ -234,13 +234,3 @@ func (m *DockerContainerListViewModel) HandleDindProcessList(model *Model) tea.C
 
 	return model.dindProcessListViewModel.Load(model, container)
 }
-
-func (m *DockerContainerListViewModel) HandleTop(model *Model) tea.Cmd {
-	container := m.GetContainer(model)
-	if container == nil {
-		slog.Error("Failed to get selected container for DinD process list")
-		return nil
-	}
-
-	return model.topViewModel.Load(model, container)
-}

--- a/internal/ui/view_docker_container_list.go
+++ b/internal/ui/view_docker_container_list.go
@@ -234,3 +234,13 @@ func (m *DockerContainerListViewModel) HandleDindProcessList(model *Model) tea.C
 
 	return model.dindProcessListViewModel.Load(model, container)
 }
+
+func (m *DockerContainerListViewModel) HandleTop(model *Model) tea.Cmd {
+	container := m.GetContainer(model)
+	if container == nil {
+		slog.Error("Failed to get selected container for DinD process list")
+		return nil
+	}
+
+	return model.topViewModel.Load(model, container)
+}

--- a/internal/ui/view_docker_container_list.go
+++ b/internal/ui/view_docker_container_list.go
@@ -180,7 +180,7 @@ func (m *DockerContainerListViewModel) GetContainer(model *Model) docker.Contain
 	// Get the selected Docker container
 	if m.selectedDockerContainer < len(m.dockerContainers) {
 		container := m.dockerContainers[m.selectedDockerContainer]
-		return docker.NewContainer(model.dockerClient, container.ID, container.Names)
+		return docker.NewContainer(model.dockerClient, container.ID, container.Names, container.Names)
 	}
 	return nil
 }

--- a/internal/ui/view_log.go
+++ b/internal/ui/view_log.go
@@ -15,11 +15,11 @@ type LogViewModel struct {
 	SearchViewModel
 	FilterViewModel
 
-	logs          []string
-	logScrollY    int
-	containerName string
-	isDindLog     bool
-	hostContainer string
+	logs              []string
+	logScrollY        int
+	containerName     string
+	isDindLog         bool
+	hostContainerName string
 
 	LogReaderManager
 }
@@ -48,7 +48,7 @@ func (m *LogViewModel) StreamComposeLogs(model *Model, composeContainer models.C
 
 func (m *LogViewModel) StreamLogsDind(model *Model, dindHostContainerID string, container models.DockerContainer) tea.Cmd {
 	m.SwitchToLogView(model, container.Names)
-	m.hostContainer = model.dindProcessListViewModel.currentDindHostName
+	m.hostContainerName = model.dindProcessListViewModel.hostContainer.GetName()
 	m.isDindLog = true
 
 	cmd := model.dockerClient.Dind(dindHostContainerID).Execute(
@@ -362,7 +362,7 @@ func (m *LogViewModel) FilterDeleteLastChar() {
 func (m *LogViewModel) Title() string {
 	title := ""
 	if m.isDindLog {
-		title = fmt.Sprintf("Logs: %s (in %s)", m.containerName, m.hostContainer)
+		title = fmt.Sprintf("Logs: %s (in %s)", m.containerName, m.hostContainerName)
 	} else {
 		title = fmt.Sprintf("Logs: %s", m.containerName)
 	}

--- a/internal/ui/view_log_test.go
+++ b/internal/ui/view_log_test.go
@@ -342,7 +342,7 @@ func TestLogViewModel_ShowMethods(t *testing.T) {
 		model := &Model{
 			currentView: DindProcessListView,
 			dindProcessListViewModel: DindProcessListViewModel{
-				hostContainer: docker.NewDindContainer(docker.NewClient(), "dind-container-id", "host-container-id", "host-container-name"),
+				hostContainer: docker.NewDindContainer(docker.NewClient(), "host-container-id", "host-container-name", "dind-container-id", "dind-container-name"),
 			},
 		}
 		container := models.DockerContainer{
@@ -354,7 +354,7 @@ func TestLogViewModel_ShowMethods(t *testing.T) {
 
 		assert.Equal(t, LogView, model.currentView)
 		assert.Equal(t, "/docker-test", model.logViewModel.containerName)
-		assert.Equal(t, "host-container", model.logViewModel.hostContainerName)
+		assert.Equal(t, "dind-container-name", model.logViewModel.hostContainerName)
 		assert.True(t, model.logViewModel.isDindLog)
 		assert.Equal(t, 0, model.logViewModel.logScrollY)
 		assert.NotNil(t, cmd)

--- a/internal/ui/view_log_test.go
+++ b/internal/ui/view_log_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/tokuhirom/dcv/internal/docker"
 
 	"github.com/tokuhirom/dcv/internal/models"

--- a/internal/ui/view_log_test.go
+++ b/internal/ui/view_log_test.go
@@ -216,7 +216,7 @@ func TestLogView_Navigation(t *testing.T) {
 				isDindLog: true,
 			},
 			dindProcessListViewModel: DindProcessListViewModel{
-				hostContainer: docker.NewDindContainer(docker.NewClient(), "dind-container-id", "host-container-id", "host-container-name"),
+				hostContainer: docker.NewDindContainer(docker.NewClient(), "host-container-id", "host-container-name", "dind-container-id", "dind-container-name"),
 			},
 		}
 

--- a/internal/ui/view_log_test.go
+++ b/internal/ui/view_log_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tokuhirom/dcv/internal/docker"
 
 	"github.com/tokuhirom/dcv/internal/models"
 )
@@ -215,7 +216,7 @@ func TestLogView_Navigation(t *testing.T) {
 				isDindLog: true,
 			},
 			dindProcessListViewModel: DindProcessListViewModel{
-				currentDindContainerID: "dind-container",
+				hostContainer: docker.NewDindContainer(docker.NewClient(), "dind-container-id", "host-container-id", "host-container-name"),
 			},
 		}
 
@@ -340,7 +341,7 @@ func TestLogViewModel_ShowMethods(t *testing.T) {
 		model := &Model{
 			currentView: DindProcessListView,
 			dindProcessListViewModel: DindProcessListViewModel{
-				currentDindHostName: "host-container",
+				hostContainer: docker.NewDindContainer(docker.NewClient(), "dind-container-id", "host-container-id", "host-container-name"),
 			},
 		}
 		container := models.DockerContainer{
@@ -352,7 +353,7 @@ func TestLogViewModel_ShowMethods(t *testing.T) {
 
 		assert.Equal(t, LogView, model.currentView)
 		assert.Equal(t, "/docker-test", model.logViewModel.containerName)
-		assert.Equal(t, "host-container", model.logViewModel.hostContainer)
+		assert.Equal(t, "host-container", model.logViewModel.hostContainerName)
 		assert.True(t, model.logViewModel.isDindLog)
 		assert.Equal(t, 0, model.logViewModel.logScrollY)
 		assert.NotNil(t, cmd)

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/tokuhirom/dcv/internal/docker"
 
 	"github.com/tokuhirom/dcv/internal/models"

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -244,7 +244,7 @@ func TestRenderDindList(t *testing.T) {
 		Height:      24,
 		loading:     false,
 		dindProcessListViewModel: DindProcessListViewModel{
-			hostContainer: docker.NewDindContainer(docker.NewClient(), "dind-1", "dind-1", "dind-1"),
+			hostContainer: docker.NewDindContainer(docker.NewClient(), "dind-1", "dind-1", "dind-1", "dind-1"),
 			dindContainers: []models.DockerContainer{
 				{
 					ID:     "abc123def456789",

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -135,7 +135,7 @@ func TestView(t *testing.T) {
 				Height:      24,
 				loading:     false,
 				dindProcessListViewModel: DindProcessListViewModel{
-					hostContainer: docker.NewDindContainer(docker.NewClient(), "dind-1", "dind-1", "dind-1"),
+					hostContainer: docker.NewDindContainer(docker.NewClient(), "dind-1", "dind-1", "dind-1", "dind-1"),
 					dindContainers: []models.DockerContainer{
 						{
 							ID:     "abc123def456",

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tokuhirom/dcv/internal/docker"
 
 	"github.com/tokuhirom/dcv/internal/models"
 )
@@ -133,7 +134,7 @@ func TestView(t *testing.T) {
 				Height:      24,
 				loading:     false,
 				dindProcessListViewModel: DindProcessListViewModel{
-					currentDindHostName: "dind-1",
+					hostContainer: docker.NewDindContainer(docker.NewClient(), "dind-1", "dind-1", "dind-1"),
 					dindContainers: []models.DockerContainer{
 						{
 							ID:     "abc123def456",
@@ -243,7 +244,7 @@ func TestRenderDindList(t *testing.T) {
 		Height:      24,
 		loading:     false,
 		dindProcessListViewModel: DindProcessListViewModel{
-			currentDindHostName: "dind-1",
+			hostContainer: docker.NewDindContainer(docker.NewClient(), "dind-1", "dind-1", "dind-1"),
 			dindContainers: []models.DockerContainer{
 				{
 					ID:     "abc123def456789",

--- a/internal/ui/view_top.go
+++ b/internal/ui/view_top.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
+
 	"github.com/tokuhirom/dcv/internal/docker"
 )
 

--- a/internal/ui/view_top.go
+++ b/internal/ui/view_top.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -11,9 +12,7 @@ import (
 type TopViewModel struct {
 	content string
 
-	container   docker.Container
-	topService  string // Deprecated: use container instead
-	projectName string // Deprecated: use container instead
+	container docker.Container
 }
 
 // render renders the top view
@@ -67,4 +66,8 @@ func (m *TopViewModel) HandleBack(model *Model) tea.Cmd {
 // Loaded updates the top output after loading
 func (m *TopViewModel) Loaded(output string) {
 	m.content = output
+}
+
+func (m *TopViewModel) Title() string {
+	return fmt.Sprintf("Process Info: %s", m.container.Title())
 }

--- a/internal/ui/view_top.go
+++ b/internal/ui/view_top.go
@@ -4,24 +4,27 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/tokuhirom/dcv/internal/docker"
 )
 
 // TopViewModel manages the state and rendering of the process info view
 type TopViewModel struct {
-	topOutput   string
-	topService  string
-	projectName string
+	content string
+
+	container   docker.Container
+	topService  string // Deprecated: use container instead
+	projectName string // Deprecated: use container instead
 }
 
 // render renders the top view
-func (m *TopViewModel) render(model *Model, availableHeight int) string {
+func (m *TopViewModel) render(availableHeight int) string {
 	var s strings.Builder
 
-	if m.topOutput == "" {
+	if m.content == "" {
 		s.WriteString("No process information available.\n")
 	} else {
 		// Display the raw top output
-		lines := strings.Split(m.topOutput, "\n")
+		lines := strings.Split(m.content, "\n")
 		visibleHeight := availableHeight
 
 		for i, line := range lines {
@@ -36,9 +39,8 @@ func (m *TopViewModel) render(model *Model, availableHeight int) string {
 }
 
 // Load switches to the top view and loads process info
-func (m *TopViewModel) Load(model *Model, projectName string, service string) tea.Cmd {
-	m.topService = service
-	m.projectName = projectName
+func (m *TopViewModel) Load(model *Model, container docker.Container) tea.Cmd {
+	m.container = container
 	model.SwitchView(TopView)
 	return m.DoLoad(model)
 }
@@ -47,11 +49,10 @@ func (m *TopViewModel) Load(model *Model, projectName string, service string) te
 func (m *TopViewModel) DoLoad(model *Model) tea.Cmd {
 	model.loading = true
 
-	// TODO: support normal containers
 	return func() tea.Msg {
-		output, err := model.dockerClient.Compose(m.projectName).Top(m.topService)
+		output, err := m.container.Top()
 		return topLoadedMsg{
-			output: output,
+			output: string(output),
 			err:    err,
 		}
 	}
@@ -65,5 +66,5 @@ func (m *TopViewModel) HandleBack(model *Model) tea.Cmd {
 
 // Loaded updates the top output after loading
 func (m *TopViewModel) Loaded(output string) {
-	m.topOutput = output
+	m.content = output
 }

--- a/internal/ui/view_top.go
+++ b/internal/ui/view_top.go
@@ -24,7 +24,7 @@ func (m *TopViewModel) render(availableHeight int) string {
 	} else {
 		// Display the raw top output
 		lines := strings.Split(m.content, "\n")
-		visibleHeight := availableHeight
+		visibleHeight := availableHeight - 2
 
 		for i, line := range lines {
 			if i >= visibleHeight {


### PR DESCRIPTION
## Summary
- Added 'top' command support (`t` key) to all process-related views for consistency
- Unified process information display across Docker container, Compose process, and DinD views
- Improved code organization with shared rendering logic

## Changes
- Added `HandleTop` method to Docker container list, Compose process list, and DinD process list views
- Created shared `renderTop` function for consistent top view rendering
- Updated key handlers and command registry for all views
- Added proper error handling and loading states

## Test plan
- [x] Verify 't' key shows process info in Docker container list view
- [x] Verify 't' key shows process info in Compose process list view  
- [x] Verify 't' key shows process info in DinD process list view
- [x] Verify navigation and refresh work correctly in top view
- [x] All tests pass with `make test`
- [x] No linting errors with `make lint`