### PR TITLE
fix: improve file browser navigation history management

### DIFF
--- a/internal/ui/update_test.go
+++ b/internal/ui/update_test.go
@@ -442,7 +442,7 @@ func TestFileBrowserParentDirectory(t *testing.T) {
 	m := newModel.(*Model)
 
 	assert.Equal(t, "/app", m.fileBrowserViewModel.currentPath)
-	assert.Equal(t, 2, len(m.fileBrowserViewModel.pathHistory)) // Should have removed the last entry
+	assert.Equal(t, 4, len(m.fileBrowserViewModel.pathHistory)) // Should have added parent to history
 	assert.True(t, m.loading)
 	assert.Equal(t, 0, m.fileBrowserViewModel.selectedFile) // Should reset selection
 	assert.NotNil(t, cmd)                                   // Should trigger loading parent directory files

--- a/internal/ui/view_file_browser_test.go
+++ b/internal/ui/view_file_browser_test.go
@@ -1,0 +1,464 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tokuhirom/dcv/internal/docker"
+	"github.com/tokuhirom/dcv/internal/models"
+)
+
+func TestFileBrowserViewModel_HistoryManagement(t *testing.T) {
+	t.Run("pushHistory adds path to history", func(t *testing.T) {
+		vm := &FileBrowserViewModel{
+			pathHistory: []string{"/"},
+			currentPath: "/",
+		}
+
+		vm.pushHistory("/usr")
+		assert.Equal(t, []string{"/", "/usr"}, vm.pathHistory)
+		assert.Equal(t, "/usr", vm.currentPath)
+
+		vm.pushHistory("/usr/local")
+		assert.Equal(t, []string{"/", "/usr", "/usr/local"}, vm.pathHistory)
+		assert.Equal(t, "/usr/local", vm.currentPath)
+	})
+
+	t.Run("popHistory removes last path and returns to previous", func(t *testing.T) {
+		vm := &FileBrowserViewModel{
+			pathHistory: []string{"/", "/usr", "/usr/local"},
+			currentPath: "/usr/local",
+		}
+
+		result := vm.popHistory()
+		assert.True(t, result)
+		assert.Equal(t, []string{"/", "/usr"}, vm.pathHistory)
+		assert.Equal(t, "/usr", vm.currentPath)
+
+		result = vm.popHistory()
+		assert.True(t, result)
+		assert.Equal(t, []string{"/"}, vm.pathHistory)
+		assert.Equal(t, "/", vm.currentPath)
+
+		// Can't pop when only one item left
+		result = vm.popHistory()
+		assert.False(t, result)
+		assert.Equal(t, []string{"/"}, vm.pathHistory)
+		assert.Equal(t, "/", vm.currentPath)
+	})
+
+	t.Run("popHistory returns false when empty", func(t *testing.T) {
+		vm := &FileBrowserViewModel{
+			pathHistory: []string{},
+			currentPath: "",
+		}
+
+		result := vm.popHistory()
+		assert.False(t, result)
+		assert.Equal(t, []string{}, vm.pathHistory)
+	})
+}
+
+func TestFileBrowserViewModel_Rendering(t *testing.T) {
+	tests := []struct {
+		name      string
+		viewModel FileBrowserViewModel
+		model     *Model
+		height    int
+		expected  []string
+	}{
+		{
+			name: "displays no files message when empty",
+			viewModel: FileBrowserViewModel{
+				containerFiles: []models.ContainerFile{},
+				selectedFile:   0,
+				currentPath:    "/",
+			},
+			model: &Model{
+				width:  100,
+				Height: 20,
+			},
+			height:   20,
+			expected: []string{"No files found or directory is empty"},
+		},
+		{
+			name: "displays file list table",
+			viewModel: FileBrowserViewModel{
+				containerFiles: []models.ContainerFile{
+					{
+						Name:        ".",
+						Permissions: "drwxr-xr-x",
+						IsDir:       true,
+					},
+					{
+						Name:        "..",
+						Permissions: "drwxr-xr-x",
+						IsDir:       true,
+					},
+					{
+						Name:        "app",
+						Permissions: "drwxr-xr-x",
+						IsDir:       true,
+					},
+					{
+						Name:        "config.json",
+						Permissions: "-rw-r--r--",
+						IsDir:       false,
+					},
+				},
+				selectedFile: 0,
+				currentPath:  "/usr/local",
+			},
+			model: &Model{
+				width:  100,
+				Height: 20,
+			},
+			height: 20,
+			expected: []string{
+				"PERMISSIONS",
+				"NAME",
+				"drwxr-xr-x",
+				"app/",
+				"config.json",
+			},
+		},
+		{
+			name: "highlights directories with color",
+			viewModel: FileBrowserViewModel{
+				containerFiles: []models.ContainerFile{
+					{
+						Name:        "bin",
+						Permissions: "drwxr-xr-x",
+						IsDir:       true,
+					},
+					{
+						Name:        "file.txt",
+						Permissions: "-rw-r--r--",
+						IsDir:       false,
+					},
+				},
+				selectedFile: 0,
+				currentPath:  "/",
+			},
+			model: &Model{
+				width:  100,
+				Height: 20,
+			},
+			height:   20,
+			expected: []string{"bin/", "file.txt"},
+		},
+		{
+			name: "shows symlinks with arrow",
+			viewModel: FileBrowserViewModel{
+				containerFiles: []models.ContainerFile{
+					{
+						Name:        "link",
+						Permissions: "lrwxrwxrwx",
+						IsDir:       false,
+						LinkTarget:  "/target/path",
+					},
+				},
+				selectedFile: 0,
+				currentPath:  "/",
+			},
+			model: &Model{
+				width:  100,
+				Height: 20,
+			},
+			height:   20,
+			expected: []string{"link -> /target/path"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.model.fileBrowserViewModel = tt.viewModel
+			result := tt.viewModel.render(tt.model, tt.height-4)
+
+			for _, expected := range tt.expected {
+				assert.Contains(t, result, expected, "Expected to find '%s' in output", expected)
+			}
+		})
+	}
+}
+
+func TestFileBrowserViewModel_Navigation(t *testing.T) {
+	t.Run("HandleDown moves selection down", func(t *testing.T) {
+		vm := &FileBrowserViewModel{
+			containerFiles: []models.ContainerFile{
+				{Name: "file1.txt"},
+				{Name: "file2.txt"},
+				{Name: "file3.txt"},
+			},
+			selectedFile: 0,
+		}
+
+		cmd := vm.HandleDown()
+		assert.Nil(t, cmd)
+		assert.Equal(t, 1, vm.selectedFile)
+
+		// Test boundary
+		vm.selectedFile = 2
+		cmd = vm.HandleDown()
+		assert.Nil(t, cmd)
+		assert.Equal(t, 2, vm.selectedFile, "Should not go beyond last file")
+	})
+
+	t.Run("HandleUp moves selection up", func(t *testing.T) {
+		vm := &FileBrowserViewModel{
+			containerFiles: []models.ContainerFile{
+				{Name: "file1.txt"},
+				{Name: "file2.txt"},
+				{Name: "file3.txt"},
+			},
+			selectedFile: 2,
+		}
+
+		cmd := vm.HandleUp()
+		assert.Nil(t, cmd)
+		assert.Equal(t, 1, vm.selectedFile)
+
+		// Test boundary
+		vm.selectedFile = 0
+		cmd = vm.HandleUp()
+		assert.Nil(t, cmd)
+		assert.Equal(t, 0, vm.selectedFile, "Should not go below 0")
+	})
+}
+
+func TestFileBrowserViewModel_DirectoryNavigation(t *testing.T) {
+	t.Run("HandleGoToParentDirectory goes up one level", func(t *testing.T) {
+		model := &Model{
+			dockerClient: docker.NewClient(),
+			loading:      false,
+		}
+		vm := &FileBrowserViewModel{
+			currentPath: "/usr/local/bin",
+			pathHistory: []string{"/", "/usr", "/usr/local", "/usr/local/bin"},
+		}
+
+		cmd := vm.HandleGoToParentDirectory(model)
+		assert.NotNil(t, cmd)
+		assert.Equal(t, "/usr/local", vm.currentPath)
+		// pushHistory appends the parent path
+		assert.Equal(t, []string{"/", "/usr", "/usr/local", "/usr/local/bin", "/usr/local"}, vm.pathHistory)
+		assert.Equal(t, 0, vm.selectedFile)
+	})
+
+	t.Run("HandleGoToParentDirectory does nothing at root", func(t *testing.T) {
+		model := &Model{
+			dockerClient: docker.NewClient(),
+			loading:      false,
+		}
+		vm := &FileBrowserViewModel{
+			currentPath: "/",
+			pathHistory: []string{"/"},
+		}
+
+		cmd := vm.HandleGoToParentDirectory(model)
+		assert.Nil(t, cmd)
+		assert.Equal(t, "/", vm.currentPath)
+		assert.Equal(t, []string{"/"}, vm.pathHistory)
+		assert.False(t, model.loading)
+	})
+}
+
+func TestFileBrowserViewModel_FileOperations(t *testing.T) {
+	t.Run("HandleOpenFileOrDirectory navigates into directory", func(t *testing.T) {
+		model := &Model{
+			dockerClient: docker.NewClient(),
+			loading:      false,
+		}
+		vm := &FileBrowserViewModel{
+			containerFiles: []models.ContainerFile{
+				{Name: "subdir", IsDir: true},
+			},
+			selectedFile: 0,
+			currentPath:  "/usr",
+			pathHistory:  []string{"/", "/usr"},
+		}
+
+		cmd := vm.HandleOpenFileOrDirectory(model)
+		assert.NotNil(t, cmd)
+		assert.Equal(t, "/usr/subdir", vm.currentPath)
+		assert.Equal(t, []string{"/", "/usr", "/usr/subdir"}, vm.pathHistory)
+		assert.Equal(t, 0, vm.selectedFile)
+	})
+
+	t.Run("HandleOpenFileOrDirectory opens file content", func(t *testing.T) {
+		model := &Model{
+			dockerClient:         docker.NewClient(),
+			loading:              false,
+			fileContentViewModel: FileContentViewModel{},
+		}
+		vm := &FileBrowserViewModel{
+			containerFiles: []models.ContainerFile{
+				{Name: "file.txt", IsDir: false},
+			},
+			selectedFile:          0,
+			currentPath:           "/usr",
+			browsingContainerID:   "container123",
+			browsingContainerName: "test-container",
+		}
+
+		cmd := vm.HandleOpenFileOrDirectory(model)
+		assert.NotNil(t, cmd)
+		// File path should be constructed and passed to file content view
+		assert.Equal(t, "/usr", vm.currentPath) // Path should not change
+	})
+
+	t.Run("HandleOpenFileOrDirectory handles .. directory", func(t *testing.T) {
+		model := &Model{
+			dockerClient: docker.NewClient(),
+			loading:      false,
+		}
+		vm := &FileBrowserViewModel{
+			containerFiles: []models.ContainerFile{
+				{Name: "..", IsDir: true},
+			},
+			selectedFile: 0,
+			currentPath:  "/usr/local",
+			pathHistory:  []string{"/", "/usr", "/usr/local"},
+		}
+
+		cmd := vm.HandleOpenFileOrDirectory(model)
+		assert.NotNil(t, cmd)
+		assert.Equal(t, "/usr", vm.currentPath)
+		assert.Equal(t, []string{"/", "/usr", "/usr/local", "/usr"}, vm.pathHistory)
+		assert.Equal(t, 0, vm.selectedFile)
+	})
+
+	t.Run("HandleOpenFileOrDirectory ignores . directory", func(t *testing.T) {
+		model := &Model{
+			dockerClient: docker.NewClient(),
+			loading:      false,
+		}
+		vm := &FileBrowserViewModel{
+			containerFiles: []models.ContainerFile{
+				{Name: ".", IsDir: true},
+			},
+			selectedFile: 0,
+			currentPath:  "/usr",
+		}
+
+		cmd := vm.HandleOpenFileOrDirectory(model)
+		assert.Nil(t, cmd)
+		assert.Equal(t, "/usr", vm.currentPath) // Path should not change
+	})
+}
+
+func TestFileBrowserViewModel_Load(t *testing.T) {
+	t.Run("Load initializes file browser", func(t *testing.T) {
+		model := &Model{
+			dockerClient: docker.NewClient(),
+			currentView:  ComposeProcessListView,
+			loading:      false,
+		}
+		vm := &FileBrowserViewModel{}
+
+		cmd := vm.Load(model, "container123", "test-container")
+		assert.NotNil(t, cmd)
+		assert.Equal(t, "container123", vm.browsingContainerID)
+		assert.Equal(t, "test-container", vm.browsingContainerName)
+		assert.Equal(t, "/", vm.currentPath)
+		assert.Equal(t, []string{"/"}, vm.pathHistory) // pushHistory adds the initial path
+		assert.Equal(t, FileBrowserView, model.currentView)
+	})
+}
+
+func TestFileBrowserViewModel_HandleBack(t *testing.T) {
+	t.Run("HandleBack navigates through path history", func(t *testing.T) {
+		model := &Model{
+			dockerClient: docker.NewClient(),
+			currentView:  FileBrowserView,
+			viewHistory:  []ViewType{ComposeProcessListView, FileBrowserView},
+		}
+		vm := &FileBrowserViewModel{
+			currentPath: "/usr/local",
+			pathHistory: []string{"/", "/usr", "/usr/local"},
+		}
+
+		cmd := vm.HandleBack(model)
+		assert.NotNil(t, cmd)
+		assert.Equal(t, "/usr", vm.currentPath)
+		assert.Equal(t, []string{"/", "/usr"}, vm.pathHistory)
+		assert.Equal(t, FileBrowserView, model.currentView) // Should stay in file browser
+	})
+
+	t.Run("HandleBack switches to previous view when no more history", func(t *testing.T) {
+		model := &Model{
+			currentView: FileBrowserView,
+			viewHistory: []ViewType{ComposeProcessListView, FileBrowserView},
+		}
+		vm := &FileBrowserViewModel{
+			currentPath: "/",
+			pathHistory: []string{"/"},
+		}
+
+		cmd := vm.HandleBack(model)
+		assert.Nil(t, cmd)
+		assert.Equal(t, ComposeProcessListView, model.currentView)
+	})
+}
+
+func TestFileBrowserViewModel_Loaded(t *testing.T) {
+	t.Run("Loaded updates container files", func(t *testing.T) {
+		vm := &FileBrowserViewModel{
+			selectedFile: 10, // Out of bounds
+		}
+
+		files := []models.ContainerFile{
+			{Name: "file1.txt"},
+			{Name: "file2.txt"},
+		}
+
+		vm.Loaded(files)
+		assert.Equal(t, files, vm.containerFiles)
+		assert.Equal(t, 0, vm.selectedFile, "Should reset selection when out of bounds")
+	})
+
+	t.Run("Loaded preserves valid selection", func(t *testing.T) {
+		vm := &FileBrowserViewModel{
+			selectedFile: 1,
+		}
+
+		files := []models.ContainerFile{
+			{Name: "file1.txt"},
+			{Name: "file2.txt"},
+			{Name: "file3.txt"},
+		}
+
+		vm.Loaded(files)
+		assert.Equal(t, files, vm.containerFiles)
+		assert.Equal(t, 1, vm.selectedFile, "Should preserve valid selection")
+	})
+}
+
+func TestFileBrowserViewModel_Title(t *testing.T) {
+	vm := &FileBrowserViewModel{
+		browsingContainerName: "test-container",
+		currentPath:           "/usr/local",
+	}
+
+	title := vm.Title()
+	assert.Equal(t, "File Browser: test-container [/usr/local]", title)
+}
+
+func TestFileBrowserViewModel_DoLoad(t *testing.T) {
+	t.Run("DoLoad returns command to load files", func(t *testing.T) {
+		model := &Model{
+			dockerClient: docker.NewClient(),
+		}
+		vm := &FileBrowserViewModel{
+			browsingContainerID: "container123",
+			currentPath:         "/usr/local",
+		}
+
+		cmd := vm.DoLoad(model)
+		assert.NotNil(t, cmd)
+
+		// Command should be created to load files
+		// We don't execute it in tests as it would require a real container
+	})
+}

--- a/internal/ui/view_file_content_test.go
+++ b/internal/ui/view_file_content_test.go
@@ -1,0 +1,337 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tokuhirom/dcv/internal/docker"
+)
+
+func TestFileContentViewModel_Rendering(t *testing.T) {
+	tests := []struct {
+		name      string
+		viewModel FileContentViewModel
+		model     *Model
+		expected  []string
+	}{
+		{
+			name: "displays file content",
+			viewModel: FileContentViewModel{
+				content:     "Line 1\nLine 2\nLine 3\nLine 4\nLine 5",
+				contentPath: "/etc/config.conf",
+				scrollY:     0,
+			},
+			model: &Model{
+				width:  100,
+				Height: 20,
+				err:    nil,
+			},
+			expected: []string{"Line 1", "Line 2", "Line 3"},
+		},
+		{
+			name: "displays error when present",
+			viewModel: FileContentViewModel{
+				content:     "",
+				contentPath: "/etc/config.conf",
+			},
+			model: &Model{
+				width:  100,
+				Height: 20,
+				err:    assert.AnError,
+			},
+			expected: []string{"Error:"},
+		},
+		{
+			name: "handles scrolling",
+			viewModel: FileContentViewModel{
+				content:     "Line 1\nLine 2\nLine 3\nLine 4\nLine 5",
+				contentPath: "/etc/config.conf",
+				scrollY:     2,
+			},
+			model: &Model{
+				width:  100,
+				Height: 20,
+				err:    nil,
+			},
+			expected: []string{"Line 3"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.model.fileContentViewModel = tt.viewModel
+			result := tt.viewModel.render(tt.model)
+
+			for _, expected := range tt.expected {
+				assert.Contains(t, result, expected, "Expected to find '%s' in output", expected)
+			}
+		})
+	}
+}
+
+func TestFileContentViewModel_Navigation(t *testing.T) {
+	t.Run("HandleDown scrolls down", func(t *testing.T) {
+		vm := &FileContentViewModel{
+			content: "Line 1\nLine 2\nLine 3\nLine 4\nLine 5\nLine 6\nLine 7\nLine 8\nLine 9\nLine 10",
+			scrollY: 0,
+		}
+
+		cmd := vm.HandleDown(10) // height = 10, visible lines = 5
+		assert.Nil(t, cmd)
+		assert.Equal(t, 1, vm.scrollY)
+
+		// Test boundary
+		vm.scrollY = 5 // Max scroll for 10 lines with height 10
+		cmd = vm.HandleDown(10)
+		assert.Nil(t, cmd)
+		assert.Equal(t, 5, vm.scrollY, "Should not scroll beyond content")
+	})
+
+	t.Run("HandleUp scrolls up", func(t *testing.T) {
+		vm := &FileContentViewModel{
+			content: "Line 1\nLine 2\nLine 3\nLine 4\nLine 5",
+			scrollY: 2,
+		}
+
+		cmd := vm.HandleUp()
+		assert.Nil(t, cmd)
+		assert.Equal(t, 1, vm.scrollY)
+
+		// Test boundary
+		vm.scrollY = 0
+		cmd = vm.HandleUp()
+		assert.Nil(t, cmd)
+		assert.Equal(t, 0, vm.scrollY, "Should not scroll above 0")
+	})
+
+	t.Run("HandleGoToStart jumps to beginning", func(t *testing.T) {
+		vm := &FileContentViewModel{
+			content: "Line 1\nLine 2\nLine 3",
+			scrollY: 2,
+		}
+
+		cmd := vm.HandleGoToStart()
+		assert.Nil(t, cmd)
+		assert.Equal(t, 0, vm.scrollY)
+	})
+
+	t.Run("HandleGoToEnd jumps to end", func(t *testing.T) {
+		content := make([]string, 20)
+		for i := range content {
+			content[i] = "Line"
+		}
+		vm := &FileContentViewModel{
+			content: strings.Join(content, "\n"),
+			scrollY: 0,
+		}
+
+		cmd := vm.HandleGoToEnd(10) // height = 10, visible lines = 5
+		assert.Nil(t, cmd)
+		assert.Equal(t, 15, vm.scrollY) // 20 lines - 5 visible = 15
+
+		// Test with short content
+		vm.content = "Line 1\nLine 2"
+		vm.scrollY = 0
+		cmd = vm.HandleGoToEnd(10)
+		assert.Nil(t, cmd)
+		assert.Equal(t, 0, vm.scrollY, "Should not scroll if content fits")
+	})
+}
+
+func TestFileContentViewModel_Load(t *testing.T) {
+	t.Run("Load initializes file content view", func(t *testing.T) {
+		model := &Model{
+			dockerClient: docker.NewClient(),
+			currentView:  FileBrowserView,
+			loading:      false,
+		}
+		vm := &FileContentViewModel{}
+
+		cmd := vm.Load(model, "container123", "test-container", "/etc/config.conf")
+		assert.NotNil(t, cmd)
+		assert.Equal(t, "test-container", vm.containerName)
+		assert.Equal(t, 0, vm.scrollY)
+		assert.Equal(t, FileContentView, model.currentView)
+		assert.True(t, model.loading)
+
+		// Command should be created to load file content
+		// We don't execute it in tests as it would require a real container
+	})
+}
+
+func TestFileContentViewModel_HandleBack(t *testing.T) {
+	t.Run("HandleBack returns to previous view", func(t *testing.T) {
+		model := &Model{
+			currentView: FileContentView,
+			viewHistory: []ViewType{FileBrowserView, FileContentView},
+		}
+		vm := &FileContentViewModel{
+			content:       "some content",
+			contentPath:   "/file.txt",
+			containerName: "test-container",
+			scrollY:       5,
+		}
+
+		cmd := vm.HandleBack(model)
+		assert.Nil(t, cmd)
+		assert.Equal(t, FileBrowserView, model.currentView)
+		assert.Empty(t, vm.content)
+		assert.Empty(t, vm.contentPath)
+		assert.Equal(t, 0, vm.scrollY)
+	})
+}
+
+func TestFileContentViewModel_Loaded(t *testing.T) {
+	t.Run("Loaded updates content and path", func(t *testing.T) {
+		vm := &FileContentViewModel{
+			scrollY: 10,
+		}
+
+		content := "New file content\nLine 2\nLine 3"
+		path := "/new/path.txt"
+
+		vm.Loaded(content, path)
+		assert.Equal(t, content, vm.content)
+		assert.Equal(t, path, vm.contentPath)
+		assert.Equal(t, 0, vm.scrollY, "Should reset scroll position")
+	})
+}
+
+func TestFileContentViewModel_Title(t *testing.T) {
+	vm := &FileContentViewModel{
+		content:       "Line 1\nLine 2\nLine 3\nLine 4\nLine 5",
+		contentPath:   "/etc/config.conf",
+		containerName: "test-container",
+		scrollY:       2,
+	}
+
+	title := vm.Title()
+	assert.Contains(t, title, "File:")
+	assert.Contains(t, title, "[2/5]") // scrollY / total lines
+	assert.Contains(t, title, "/etc/config.conf")
+	assert.Contains(t, title, "[test-container]")
+}
+
+func TestFileContentViewModel_Integration(t *testing.T) {
+	t.Run("Complete navigation flow from file browser", func(t *testing.T) {
+		// Setup model with file browser and file content views
+		model := &Model{
+			dockerClient:         docker.NewClient(),
+			currentView:          FileBrowserView,
+			viewHistory:          []ViewType{ComposeProcessListView, FileBrowserView},
+			loading:              false,
+			width:                100,
+			Height:               20,
+			fileContentViewModel: FileContentViewModel{},
+		}
+
+		// Load file content from file browser
+		vm := &FileContentViewModel{}
+		cmd := vm.Load(model, "container123", "test-container", "/etc/config.conf")
+		assert.NotNil(t, cmd)
+		assert.Equal(t, FileContentView, model.currentView)
+
+		// Simulate loading completion
+		vm.Loaded("File content here", "/etc/config.conf")
+		assert.Equal(t, "File content here", vm.content)
+
+		// Navigate back should return to file browser
+		cmd = vm.HandleBack(model)
+		assert.Nil(t, cmd)
+		assert.Equal(t, FileBrowserView, model.currentView)
+	})
+
+	t.Run("Navigation flow from other views", func(t *testing.T) {
+		// Setup model starting from compose process list
+		model := &Model{
+			dockerClient:         docker.NewClient(),
+			currentView:          ComposeProcessListView,
+			viewHistory:          []ViewType{DockerContainerListView, ComposeProcessListView},
+			loading:              false,
+			fileContentViewModel: FileContentViewModel{},
+		}
+
+		// Setup model with FileContentView
+		vm := &FileContentViewModel{}
+		model.currentView = FileContentView
+		model.viewHistory = []ViewType{ComposeProcessListView, FileContentView}
+
+		// Navigate back should return to previous view (compose process list)
+		cmd := vm.HandleBack(model)
+		assert.Nil(t, cmd)
+		assert.Equal(t, ComposeProcessListView, model.currentView)
+	})
+}
+
+// Test helper functions
+func TestFileContentViewModel_ScrollBoundaries(t *testing.T) {
+	t.Run("Scroll boundaries with varying content sizes", func(t *testing.T) {
+		testCases := []struct {
+			name         string
+			contentLines int
+			height       int
+			expectedMax  int
+		}{
+			{"Short content", 3, 10, 0},
+			{"Exact fit", 5, 10, 0},
+			{"Long content", 20, 10, 15},
+			{"Very long content", 100, 10, 95},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				lines := make([]string, tc.contentLines)
+				for i := range lines {
+					lines[i] = "Line"
+				}
+				vm := &FileContentViewModel{
+					content: strings.Join(lines, "\n"),
+					scrollY: 0,
+				}
+
+				// Jump to end
+				vm.HandleGoToEnd(tc.height)
+				assert.Equal(t, tc.expectedMax, vm.scrollY)
+
+				// Try to scroll beyond
+				vm.HandleDown(tc.height)
+				assert.Equal(t, tc.expectedMax, vm.scrollY, "Should not scroll beyond max")
+
+				// Jump to start
+				vm.HandleGoToStart()
+				assert.Equal(t, 0, vm.scrollY)
+
+				// Try to scroll above start
+				vm.HandleUp()
+				assert.Equal(t, 0, vm.scrollY, "Should not scroll above 0")
+			})
+		}
+	})
+}
+
+func TestFileContentViewModel_EmptyContent(t *testing.T) {
+	t.Run("Handles empty content gracefully", func(t *testing.T) {
+		vm := &FileContentViewModel{
+			content:     "",
+			contentPath: "/empty/file",
+			scrollY:     0,
+		}
+
+		// Should not crash on navigation
+		vm.HandleDown(10)
+		assert.Equal(t, 0, vm.scrollY)
+
+		vm.HandleUp()
+		assert.Equal(t, 0, vm.scrollY)
+
+		vm.HandleGoToEnd(10)
+		assert.Equal(t, 0, vm.scrollY)
+
+		vm.HandleGoToStart()
+		assert.Equal(t, 0, vm.scrollY)
+	})
+}
+
+// Test message types are already defined in model.go


### PR DESCRIPTION
## Summary
- Fixes #148: Implements proper path history management in FileBrowserViewModel
- When pressing `Esc`/`q` in file browser, it now navigates back through the directory history
- Only returns to the previous view (e.g., process list) when there's no more path history
- Added comprehensive test coverage for file browser and file content views

## Changes
- Modified `HandleBack` in `FileBrowserViewModel` to use path history for navigation
- Fixed `HandleGoToParentDirectory` and ".." handling to properly append to history instead of removing from it
- Added extensive test suites for both file browser and file content views
- Updated existing test expectations to match the new behavior

## Behavior
- When navigating directories (entering folders, using `u` key, or selecting `..`), the path is added to history
- Pressing `Esc`/`q` navigates back through the history (like a browser back button)
- Only when at the initial path does `Esc`/`q` return to the previous view

## Test plan
- [x] All existing tests pass
- [x] New tests added for file browser view
- [x] New tests added for file content view
- [x] Manual testing of navigation flow

🤖 Generated with [Claude Code](https://claude.ai/code)