### PR TITLE
feat: add file browser support for DindProcessListView

### DIFF
--- a/internal/docker/dind_client.go
+++ b/internal/docker/dind_client.go
@@ -34,3 +34,28 @@ func (d *DindClient) ListContainers(showAll bool) ([]models.DockerContainer, err
 func (d *DindClient) Execute(args ...string) *exec.Cmd {
 	return Execute(append([]string{"exec", d.hostContainerID, "docker"}, args...)...)
 }
+
+func (d *DindClient) ListContainerFiles(containerID, path string) ([]models.ContainerFile, error) {
+	// Use ls -la to get detailed file information through the host container
+	// docker exec <host-container> docker exec <nested-container> ls -la <path>
+	args := []string{"exec", d.hostContainerID, "docker", "exec", containerID, "ls", "-la", path}
+	output, err := ExecuteCaptured(args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list files in dind container: %w\nOutput: %s", err, string(output))
+	}
+
+	files := models.ParseLsOutput(string(output))
+	return files, nil
+}
+
+func (d *DindClient) ReadContainerFile(containerID, path string) (string, error) {
+	// Read file content through the host container
+	// docker exec <host-container> docker exec <nested-container> cat <path>
+	args := []string{"exec", d.hostContainerID, "docker", "exec", containerID, "cat", path}
+	output, err := ExecuteCaptured(args...)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file in dind container: %w\nOutput: %s", err, string(output))
+	}
+
+	return string(output), nil
+}

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -105,6 +105,16 @@ func (c *Client) ListContainerFiles(containerID, path string) ([]models.Containe
 	return files, nil
 }
 
+func (c *Client) ReadContainerFile(containerID, path string) (string, error) {
+	// Read file content using cat
+	output, err := ExecuteCaptured("exec", containerID, "cat", path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file in container: %w\nOutput: %s", err, string(output))
+	}
+
+	return string(output), nil
+}
+
 func (c *Client) ExecuteInteractive(containerID string, command []string) error {
 	// Build docker exec command with -it flags for interactive session
 	args := append([]string{"exec", "-it", containerID}, command...)

--- a/internal/ui/keyhandler_file_browser.go
+++ b/internal/ui/keyhandler_file_browser.go
@@ -10,6 +10,8 @@ func (m *Model) CmdFileBrowse(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, m.composeProcessListViewModel.HandleFileBrowse(m)
 	case DockerContainerListView:
 		return m, m.dockerContainerListViewModel.HandleFileBrowse(m)
+	case DindProcessListView:
+		return m, m.dindProcessListViewModel.HandleFileBrowse(m)
 	default:
 		return m, nil
 	}

--- a/internal/ui/keymap.go
+++ b/internal/ui/keymap.go
@@ -87,10 +87,7 @@ func (m *Model) initializeKeyHandlers() {
 		{[]string{"?"}, "help", m.CmdHelp},
 
 		{[]string{"i"}, "inspect", m.CmdInspect},
-		// TODO: support file browser
-
-		// TODO: support all containerOperations.
-		// TODO: {[]string{"f"}, "browse files", m.CmdFileBrowse},
+		{[]string{"f"}, "browse files", m.CmdFileBrowse},
 		{[]string{"!"}, "exec /bin/sh", m.CmdShell},
 		{[]string{"a"}, "toggle all", m.CmdToggleAll},
 		{[]string{"K"}, "kill", m.CmdKill},

--- a/internal/ui/view_dind_process_list.go
+++ b/internal/ui/view_dind_process_list.go
@@ -190,6 +190,21 @@ func (m *DindProcessListViewModel) HandleShell(model *Model) tea.Cmd {
 	}
 }
 
+func (m *DindProcessListViewModel) HandleFileBrowse(model *Model) tea.Cmd {
+	if m.selectedDindContainer >= len(m.dindContainers) {
+		slog.Error("Failed to get selected container for file browser",
+			slog.Any("error", fmt.Errorf("no container selected")))
+		return nil
+	}
+
+	// Use the nested container's ID and name for file browsing
+	nestedContainer := m.dindContainers[m.selectedDindContainer]
+	return model.fileBrowserViewModel.LoadDind(model,
+		m.hostContainer.GetContainerID(),
+		nestedContainer.ID,
+		nestedContainer.Names)
+}
+
 func (m *DindProcessListViewModel) Title() string {
 	if m.showAll {
 		return fmt.Sprintf("Docker in Docker: %s (all)", m.hostContainer.GetName())

--- a/internal/ui/view_dind_process_list_test.go
+++ b/internal/ui/view_dind_process_list_test.go
@@ -592,6 +592,89 @@ func TestDindProcessListViewModel_HandleShell(t *testing.T) {
 	})
 }
 
+func TestDindProcessListViewModel_HandleFileBrowse(t *testing.T) {
+	t.Run("HandleFileBrowse returns nil when no containers", func(t *testing.T) {
+		model := &Model{
+			dockerClient: docker.NewClient(),
+		}
+		vm := &DindProcessListViewModel{
+			dindContainers:        []models.DockerContainer{},
+			selectedDindContainer: 0,
+			hostContainer: docker.NewContainer(
+				docker.NewClient(), "host-1", "host-container", "test", "running",
+			),
+		}
+
+		cmd := vm.HandleFileBrowse(model)
+		assert.Nil(t, cmd)
+	})
+
+	t.Run("HandleFileBrowse returns nil when selection out of bounds", func(t *testing.T) {
+		model := &Model{
+			dockerClient: docker.NewClient(),
+		}
+		vm := &DindProcessListViewModel{
+			dindContainers: []models.DockerContainer{
+				{ID: "1", Names: "container-1"},
+			},
+			selectedDindContainer: 5, // Out of bounds
+			hostContainer: docker.NewContainer(
+				docker.NewClient(), "host-1", "host-container", "test", "running",
+			),
+		}
+
+		cmd := vm.HandleFileBrowse(model)
+		assert.Nil(t, cmd)
+	})
+
+	t.Run("HandleFileBrowse initiates file browser for selected container", func(t *testing.T) {
+		model := &Model{
+			dockerClient:         docker.NewClient(),
+			fileBrowserViewModel: FileBrowserViewModel{},
+		}
+		vm := &DindProcessListViewModel{
+			dindContainers: []models.DockerContainer{
+				{ID: "abc123", Names: "container-1"},
+				{ID: "def456", Names: "container-2"},
+			},
+			selectedDindContainer: 1,
+			hostContainer: docker.NewContainer(
+				docker.NewClient(), "host-1", "host-container", "test", "running",
+			),
+		}
+
+		cmd := vm.HandleFileBrowse(model)
+		assert.NotNil(t, cmd)
+		// Check that the file browser was loaded with correct DinD parameters
+		assert.Equal(t, "host-1", model.fileBrowserViewModel.hostContainerID)
+		assert.Equal(t, "def456", model.fileBrowserViewModel.browsingContainerID)
+		assert.Equal(t, "container-2", model.fileBrowserViewModel.browsingContainerName)
+		assert.True(t, model.fileBrowserViewModel.isDind)
+	})
+
+	t.Run("CmdFileBrowse works with DinD view", func(t *testing.T) {
+		model := &Model{
+			currentView:          DindProcessListView,
+			dockerClient:         docker.NewClient(),
+			fileBrowserViewModel: FileBrowserViewModel{},
+		}
+		model.dindProcessListViewModel = DindProcessListViewModel{
+			dindContainers: []models.DockerContainer{
+				{ID: "abc123", Names: "container-1", State: "running"},
+			},
+			selectedDindContainer: 0,
+			hostContainer: docker.NewContainer(
+				docker.NewClient(), "host-1", "host-container", "test", "running",
+			),
+		}
+		model.initializeKeyHandlers()
+
+		// Test file browse via CmdFileBrowse
+		_, cmd := model.CmdFileBrowse(tea.KeyMsg{})
+		assert.NotNil(t, cmd)
+	})
+}
+
 func TestDindProcessListViewModel_Title(t *testing.T) {
 	t.Run("normal title without all", func(t *testing.T) {
 		vm := &DindProcessListViewModel{

--- a/internal/ui/view_file_content.go
+++ b/internal/ui/view_file_content.go
@@ -36,9 +36,26 @@ func (m *FileContentViewModel) Load(model *Model, containerID, containerName, pa
 	m.containerName = containerName
 
 	return func() tea.Msg {
-		content, err := model.dockerClient.ExecuteCaptured("exec", containerID, "cat", path)
+		content, err := model.dockerClient.ReadContainerFile(containerID, path)
 		return fileContentLoadedMsg{
-			content: string(content),
+			content: content,
+			path:    path,
+			err:     err,
+		}
+	}
+}
+
+func (m *FileContentViewModel) LoadDind(model *Model, hostContainerID, containerID, containerName, path string) tea.Cmd {
+	model.SwitchView(FileContentView)
+	model.loading = true
+	m.scrollY = 0
+	m.containerName = containerName
+
+	return func() tea.Msg {
+		dindClient := model.dockerClient.Dind(hostContainerID)
+		content, err := dindClient.ReadContainerFile(containerID, path)
+		return fileContentLoadedMsg{
+			content: content,
 			path:    path,
 			err:     err,
 		}


### PR DESCRIPTION
## Summary
- Added file browser support for browsing and viewing files in nested containers within Docker-in-Docker (DinD) environments
- Users can now browse files in nested containers using the `f` key in DindProcessListView
- File operations are properly routed through the host container to reach nested containers

## Changes

### File Browser Support
- Implemented `HandleFileBrowse` method in `DindProcessListViewModel` to handle file browsing in nested containers
- Added `ListContainerFiles` and `ReadContainerFile` methods to `DindClient` for nested container file operations
- Added `LoadDind` methods to `FileBrowserViewModel` and `FileContentViewModel` to handle DinD-specific file operations
- Updated file browser to route file operations through host container for DinD environments
- Enabled `f` key binding in DinD keymap for file browser access
- Added `ReadContainerFile` method to Docker client for regular containers

### Implementation Details
- File listing uses: `docker exec <host-container> docker exec <nested-container> ls -la <path>`
- File reading uses: `docker exec <host-container> docker exec <nested-container> cat <path>`
- FileBrowserViewModel tracks whether it's in DinD mode and the host container ID
- FileContentViewModel has separate loading paths for regular and DinD containers

## Test Plan
- [x] Run `make fmt` to ensure proper formatting
- [x] Run `make test` to verify all tests pass
- [x] Test file browsing in DinD containers manually
- [x] Verify that file operations properly route through host container
- [x] Confirm `f` key binding works in DinD view for file browser
- [x] Test navigating directories and viewing file contents in nested containers
- [x] Added comprehensive test coverage for file browser functionality

🤖 Generated with [Claude Code](https://claude.ai/code)