### PR TITLE
refactor: simplify Docker Compose container listing API

### DIFF
--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -17,14 +17,10 @@ func NewClient() *Client {
 	return &Client{}
 }
 
-// composeClient provides compose-specific operations
-type composeClient struct {
-	projectName string
-}
-
-func (c *composeClient) ListContainers(showAll bool) ([]models.ComposeContainer, error) {
+// ListComposeContainers lists containers for a Docker Compose project
+func (c *Client) ListComposeContainers(projectName string, showAll bool) ([]models.ComposeContainer, error) {
 	// Always use JSON format for reliable parsing
-	args := []string{"compose", "-p", c.projectName, "ps", "--format", "json", "--no-trunc"}
+	args := []string{"compose", "-p", projectName, "ps", "--format", "json", "--no-trunc"}
 	if showAll {
 		args = append(args, "--all")
 	}
@@ -41,12 +37,6 @@ func (c *composeClient) ListContainers(showAll bool) ([]models.ComposeContainer,
 	// Parse JSON format
 	slog.Info("Parsing docker compose ps output")
 	return ParseComposePSJSON(output)
-}
-
-func (c *Client) Compose(projectName string) *composeClient {
-	return &composeClient{
-		projectName: projectName,
-	}
 }
 
 func (c *Client) Dind(dindHostContainerID string) *DindClient {

--- a/internal/ui/view_compose_process_list.go
+++ b/internal/ui/view_compose_process_list.go
@@ -33,7 +33,7 @@ func (m *ComposeProcessListViewModel) DoLoad(model *Model) tea.Cmd {
 	return func() tea.Msg {
 		slog.Info("Loading composeContainers",
 			slog.Bool("showAll", m.showAll))
-		processes, err := model.dockerClient.Compose(m.projectName).ListContainers(m.showAll)
+		processes, err := model.dockerClient.ListComposeContainers(m.projectName, m.showAll)
 		return processesLoadedMsg{
 			processes: processes,
 			err:       err,


### PR DESCRIPTION
## Summary
- Simplified the Docker Compose container listing API by removing the intermediate `composeClient` type
- Changed from `Compose(projName).ListContainers(showAll)` to `ListComposeContainers(projName, showAll)` for a more direct, cleaner API

## Changes
- Added new `ListComposeContainers(projectName, showAll)` method directly on the `Client` struct
- Updated the caller in `view_compose_process_list.go` to use the new method
- Removed the `composeClient` type and its methods as they're no longer needed

## Test plan
- [x] All existing tests pass
- [x] Code formatted with `make fmt`
- [x] Tests run with `make test`

🤖 Generated with [Claude Code](https://claude.ai/code)