### PR TITLE
refactor: simplify Container interface to be purely informational

### DIFF
--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -2,12 +2,9 @@ package docker
 
 import (
 	"fmt"
-
-	"github.com/tokuhirom/dcv/internal/models"
 )
 
 type Container interface {
-	Inspect() ([]byte, error)
 	GetName() string
 	GetContainerID() string
 	GetState() string
@@ -18,17 +15,19 @@ type Container interface {
 	// For DinD containers: includes host container info (e.g., "DinD: host-container (nested-container)")
 	Title() string
 
-	Top() ([]byte, error)
+	// OperationArgs returns Docker command arguments for operations on this container.
+	// For regular containers: [cmd, containerID]
+	// For DinD containers: [exec, hostID, docker, cmd, containerID]
 	OperationArgs(cmd string) []string
 
-	// File operations
-	ListContainerFiles(path string) ([]models.ContainerFile, error)
-	ReadContainerFile(path string) (string, error)
+	// FileOperationArgs returns Docker command arguments for file operations.
+	// For regular containers: [exec, containerID, fileCmd...]
+	// For DinD containers: [exec, hostID, docker, exec, containerID, fileCmd...]
+	FileOperationArgs(fileCmd ...string) []string
 }
 
 type ContainerImpl struct {
 	containerID string
-	client      *Client
 	name        string
 	title       string
 	state       string
@@ -36,7 +35,6 @@ type ContainerImpl struct {
 
 func NewContainer(client *Client, containerID string, name string, title string, state string) Container {
 	return ContainerImpl{
-		client:      client,
 		containerID: containerID,
 		name:        name,
 		title:       title,
@@ -45,14 +43,6 @@ func NewContainer(client *Client, containerID string, name string, title string,
 
 func (c ContainerImpl) ContainerID() string {
 	return c.containerID
-}
-
-func (c ContainerImpl) Inspect() ([]byte, error) {
-	captured, err := c.client.ExecuteCaptured("inspect", c.containerID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to execute docker inspect: %w\nOutput: %s", err, string(captured))
-	}
-	return captured, nil
 }
 
 func (c ContainerImpl) GetName() string {
@@ -71,24 +61,16 @@ func (c ContainerImpl) Title() string {
 	return c.title
 }
 
-func (c ContainerImpl) Top() ([]byte, error) {
-	return c.client.ExecuteCaptured("top", c.containerID)
-}
-
 func (c ContainerImpl) OperationArgs(cmd string) []string {
 	return []string{cmd, c.containerID}
 }
 
-func (c ContainerImpl) ListContainerFiles(path string) ([]models.ContainerFile, error) {
-	return c.client.ListContainerFiles(c.containerID, path)
-}
-
-func (c ContainerImpl) ReadContainerFile(path string) (string, error) {
-	return c.client.ReadContainerFile(c.containerID, path)
+func (c ContainerImpl) FileOperationArgs(fileCmd ...string) []string {
+	args := []string{"exec", c.containerID}
+	return append(args, fileCmd...)
 }
 
 type DindContainerImpl struct {
-	client            *Client
 	hostContainerName string
 	hostContainerID   string
 	containerID       string
@@ -98,7 +80,6 @@ type DindContainerImpl struct {
 
 func NewDindContainer(client *Client, hostContainerID, hostContainerName, containerID, name, state string) Container {
 	return DindContainerImpl{
-		client:            client,
 		hostContainerID:   hostContainerID,
 		hostContainerName: hostContainerName,
 		containerID:       containerID,
@@ -115,14 +96,6 @@ func (c DindContainerImpl) GetState() string {
 	return c.state
 }
 
-func (c DindContainerImpl) Inspect() ([]byte, error) {
-	captured, err := c.client.ExecuteCaptured("exec", c.hostContainerID, "docker", "inspect", c.containerID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to execute docker inspect: %w\nOutput: %s", err, string(captured))
-	}
-	return captured, nil
-}
-
 func (c DindContainerImpl) GetName() string {
 	return c.name
 }
@@ -131,35 +104,11 @@ func (c DindContainerImpl) Title() string {
 	return fmt.Sprintf("DinD: %s (%s)", c.hostContainerName, c.name)
 }
 
-func (c DindContainerImpl) Top() ([]byte, error) {
-	return c.client.ExecuteCaptured("exec", c.hostContainerID, "docker", "top", c.containerID)
-}
-
 func (c DindContainerImpl) OperationArgs(op string) []string {
 	return []string{"exec", c.hostContainerID, "docker", op, c.containerID}
 }
 
-func (c DindContainerImpl) ListContainerFiles(path string) ([]models.ContainerFile, error) {
-	// Use ls -la to get detailed file information through the host container
-	// docker exec <host-container> docker exec <nested-container> ls -la <path>
-	args := []string{"exec", c.hostContainerID, "docker", "exec", c.containerID, "ls", "-la", path}
-	output, err := ExecuteCaptured(args...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list files in dind container: %w\nOutput: %s", err, string(output))
-	}
-
-	files := models.ParseLsOutput(string(output))
-	return files, nil
-}
-
-func (c DindContainerImpl) ReadContainerFile(path string) (string, error) {
-	// Read file content through the host container
-	// docker exec <host-container> docker exec <nested-container> cat <path>
-	args := []string{"exec", c.hostContainerID, "docker", "exec", c.containerID, "cat", path}
-	output, err := ExecuteCaptured(args...)
-	if err != nil {
-		return "", fmt.Errorf("failed to read file in dind container: %w\nOutput: %s", err, string(output))
-	}
-
-	return string(output), nil
+func (c DindContainerImpl) FileOperationArgs(fileCmd ...string) []string {
+	args := []string{"exec", c.hostContainerID, "docker", "exec", c.containerID}
+	return append(args, fileCmd...)
 }

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -125,27 +125,6 @@ func (c *Client) ListNetworks() ([]models.DockerNetwork, error) {
 	return networks, nil
 }
 
-func (c *Client) ListContainerFiles(containerID, path string) ([]models.ContainerFile, error) {
-	// Use ls -la to get detailed file information
-	output, err := ExecuteCaptured("exec", containerID, "ls", "-la", path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list files in container: %w\nOutput: %s", err, string(output))
-	}
-
-	files := models.ParseLsOutput(string(output))
-	return files, nil
-}
-
-func (c *Client) ReadContainerFile(containerID, path string) (string, error) {
-	// Read file content using cat
-	output, err := ExecuteCaptured("exec", containerID, "cat", path)
-	if err != nil {
-		return "", fmt.Errorf("failed to read file in container: %w\nOutput: %s", err, string(output))
-	}
-
-	return string(output), nil
-}
-
 func (c *Client) ExecuteInteractive(containerID string, command []string) error {
 	// Build docker exec command with -it flags for interactive session
 	args := append([]string{"exec", "-it", containerID}, command...)

--- a/internal/ui/view_compose_process_list.go
+++ b/internal/ui/view_compose_process_list.go
@@ -222,7 +222,8 @@ func (m *ComposeProcessListViewModel) HandleInspect(model *Model) tea.Cmd {
 	return model.inspectViewModel.Inspect(model,
 		fmt.Sprintf("compose process: %s(%s)", container.GetName(), m.projectName),
 		func() ([]byte, error) {
-			return container.Inspect()
+			args := container.OperationArgs("inspect")
+			return model.dockerClient.ExecuteCaptured(args...)
 		})
 }
 

--- a/internal/ui/view_dind_process_list.go
+++ b/internal/ui/view_dind_process_list.go
@@ -156,7 +156,8 @@ func (m *DindProcessListViewModel) HandleInspect(model *Model) tea.Cmd {
 	return model.inspectViewModel.Inspect(model,
 		fmt.Sprintf("DinD: %s (%s)", m.hostContainer.GetName(), container.GetName()),
 		func() ([]byte, error) {
-			return container.Inspect()
+			args := container.OperationArgs("inspect")
+			return model.dockerClient.ExecuteCaptured(args...)
 		},
 	)
 }

--- a/internal/ui/view_docker_container_list.go
+++ b/internal/ui/view_docker_container_list.go
@@ -177,7 +177,8 @@ func (m *DockerContainerListViewModel) HandleInspect(model *Model) tea.Cmd {
 	return model.inspectViewModel.Inspect(model,
 		"container "+container.GetName(),
 		func() ([]byte, error) {
-			return container.Inspect()
+			args := container.OperationArgs("inspect")
+			return model.dockerClient.ExecuteCaptured(args...)
 		})
 }
 

--- a/internal/ui/view_file_browser.go
+++ b/internal/ui/view_file_browser.go
@@ -166,7 +166,14 @@ func (m *FileBrowserViewModel) Loaded(files []models.ContainerFile) {
 func (m *FileBrowserViewModel) DoLoad(model *Model) tea.Cmd {
 	model.loading = true
 	return func() tea.Msg {
-		files, err := m.browsingContainer.ListContainerFiles(m.currentPath)
+		args := m.browsingContainer.FileOperationArgs("ls", "-la", m.currentPath)
+		output, err := model.dockerClient.ExecuteCaptured(args...)
+
+		var files []models.ContainerFile
+		if err == nil {
+			files = models.ParseLsOutput(string(output))
+		}
+
 		return containerFilesLoadedMsg{
 			files: files,
 			err:   err,

--- a/internal/ui/view_file_content.go
+++ b/internal/ui/view_file_content.go
@@ -38,9 +38,10 @@ func (m *FileContentViewModel) LoadContainer(model *Model, container docker.Cont
 	m.container = container
 
 	return func() tea.Msg {
-		content, err := container.ReadContainerFile(path)
+		args := container.FileOperationArgs("cat", path)
+		output, err := model.dockerClient.ExecuteCaptured(args...)
 		return fileContentLoadedMsg{
-			content: content,
+			content: string(output),
 			path:    path,
 			err:     err,
 		}

--- a/internal/ui/view_top.go
+++ b/internal/ui/view_top.go
@@ -50,7 +50,8 @@ func (m *TopViewModel) DoLoad(model *Model) tea.Cmd {
 	model.loading = true
 
 	return func() tea.Msg {
-		output, err := m.container.Top()
+		args := m.container.OperationArgs("top")
+		output, err := model.dockerClient.ExecuteCaptured(args...)
 		return topLoadedMsg{
 			output: string(output),
 			err:    err,


### PR DESCRIPTION
## Summary
The Container interface was doing too much - both executing commands and parsing results. This refactoring follows the principle that execution should be handled by the caller, making the Container interface a pure data provider.

## Changes
- **Simplified Container interface**: Removed all execution methods (`Inspect()`, `Top()`, `ListContainerFiles()`, `ReadContainerFile()`)
- **Added helper methods**: Added `OperationArgs()` and `FileOperationArgs()` to provide correct Docker command arguments
- **Moved execution to UI layer**: All Docker command execution now happens in the UI layer where it belongs
- **Removed dependencies**: Removed `client` field from container structs and unnecessary imports
- **Cleaned up docker.go**: Removed unused `ListContainerFiles()` and `ReadContainerFile()` methods

## Benefits
- **Cleaner separation of concerns**: Container objects are now simple data providers
- **Better consistency**: Same pattern for both regular and DinD containers  
- **Improved testability**: Execution logic is now in one place
- **Simpler code**: Container implementation is much cleaner and focused
- **Better maintainability**: Clear responsibility boundaries

## Test plan
- [x] All existing tests pass
- [x] Code formatted with `make fmt`
- [x] Tests run with `make test`

🤖 Generated with [Claude Code](https://claude.ai/code)