### PR TITLE
refactor: unify OperationArgs and FileOperationArgs into single method

### DIFF
--- a/internal/ui/view_file_browser.go
+++ b/internal/ui/view_file_browser.go
@@ -166,7 +166,7 @@ func (m *FileBrowserViewModel) Loaded(files []models.ContainerFile) {
 func (m *FileBrowserViewModel) DoLoad(model *Model) tea.Cmd {
 	model.loading = true
 	return func() tea.Msg {
-		args := m.browsingContainer.FileOperationArgs("ls", "-la", m.currentPath)
+		args := m.browsingContainer.OperationArgs("exec", "ls", "-la", m.currentPath)
 		output, err := model.dockerClient.ExecuteCaptured(args...)
 
 		var files []models.ContainerFile

--- a/internal/ui/view_file_content.go
+++ b/internal/ui/view_file_content.go
@@ -38,7 +38,7 @@ func (m *FileContentViewModel) LoadContainer(model *Model, container docker.Cont
 	m.container = container
 
 	return func() tea.Msg {
-		args := container.FileOperationArgs("cat", path)
+		args := container.OperationArgs("exec", "cat", path)
 		output, err := model.dockerClient.ExecuteCaptured(args...)
 		return fileContentLoadedMsg{
 			content: string(output),


### PR DESCRIPTION
## Summary
Further simplified the Container interface by merging `FileOperationArgs` into `OperationArgs` with variadic extra arguments, as suggested in the previous PR review.

## Changes
- Merged `FileOperationArgs` functionality into `OperationArgs(cmd, extraArgs...)`
- Updated `OperationArgs` to accept variadic extra arguments
- Updated file operation callers to use `OperationArgs("exec", command...)`
- Added special handling for DinD exec operations to correctly construct the command

## Benefits
- **Simpler API**: Single method instead of two
- **More flexible**: Can handle any operation with extra arguments
- **Cleaner interface**: Reduced API surface area
- **Consistent pattern**: All operations now use the same method

## Test plan
- [x] All existing tests pass
- [x] Code formatted with `make fmt`
- [x] Tests run with `make test`

🤖 Generated with [Claude Code](https://claude.ai/code)