### PR TITLE
refactor: unify ContainerImpl and DindContainerImpl into single Container struct

### DIFF
--- a/internal/ui/keyhandler_base.go
+++ b/internal/ui/keyhandler_base.go
@@ -17,5 +17,5 @@ type KeyConfig struct {
 }
 
 type GetContainerAware interface {
-	GetContainer(model *Model) docker.Container
+	GetContainer(model *Model) *docker.Container
 }

--- a/internal/ui/keyhandler_docker.go
+++ b/internal/ui/keyhandler_docker.go
@@ -11,35 +11,35 @@ import (
 // Docker container management commands
 
 func (m *Model) CmdKill(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	return m, m.useContainerAware(func(container docker.Container) tea.Cmd {
+	return m, m.useContainerAware(func(container *docker.Container) tea.Cmd {
 		args := container.OperationArgs("kill")
 		return m.commandExecutionViewModel.ExecuteCommand(m, true, args...) // kill is aggressive
 	})
 }
 
 func (m *Model) CmdStop(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	return m, m.useContainerAware(func(container docker.Container) tea.Cmd {
+	return m, m.useContainerAware(func(container *docker.Container) tea.Cmd {
 		args := container.OperationArgs("stop")
 		return m.commandExecutionViewModel.ExecuteCommand(m, true, args...) // stop is aggressive
 	})
 }
 
 func (m *Model) CmdStart(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	return m, m.useContainerAware(func(container docker.Container) tea.Cmd {
+	return m, m.useContainerAware(func(container *docker.Container) tea.Cmd {
 		args := container.OperationArgs("start")
 		return m.commandExecutionViewModel.ExecuteCommand(m, true, args...) // start is aggressive
 	})
 }
 
 func (m *Model) CmdRestart(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	return m, m.useContainerAware(func(container docker.Container) tea.Cmd {
+	return m, m.useContainerAware(func(container *docker.Container) tea.Cmd {
 		args := container.OperationArgs("restart")
 		return m.commandExecutionViewModel.ExecuteCommand(m, true, args...) // start is aggressive
 	})
 }
 
 func (m *Model) CmdPause(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	return m, m.useContainerAware(func(container docker.Container) tea.Cmd {
+	return m, m.useContainerAware(func(container *docker.Container) tea.Cmd {
 		cmd := func() string {
 			if container.GetState() == "paused" {
 				return "unpause"
@@ -106,12 +106,12 @@ func (m *Model) CmdInspect(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m *Model) CmdTop(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	return m, m.useContainerAware(func(container docker.Container) tea.Cmd {
+	return m, m.useContainerAware(func(container *docker.Container) tea.Cmd {
 		return m.topViewModel.Load(m, container)
 	})
 }
 
-func (m *Model) useContainerAware(cb func(container docker.Container) tea.Cmd) tea.Cmd {
+func (m *Model) useContainerAware(cb func(container *docker.Container) tea.Cmd) tea.Cmd {
 	// if GetContainerAware, we can show top for containers
 	// GetContainerAware is the interface that provides container-aware functionality
 	vm := m.GetCurrentViewModel()

--- a/internal/ui/view_compose_process_list.go
+++ b/internal/ui/view_compose_process_list.go
@@ -203,7 +203,7 @@ func (m *ComposeProcessListViewModel) HandleShell() tea.Cmd {
 	return nil
 }
 
-func (m *ComposeProcessListViewModel) GetContainer(model *Model) docker.Container {
+func (m *ComposeProcessListViewModel) GetContainer(model *Model) *docker.Container {
 	if m.selectedContainer < len(m.composeContainers) {
 		container := m.composeContainers[m.selectedContainer]
 		return docker.NewContainer(model.dockerClient, container.ID, container.Name,

--- a/internal/ui/view_dind_process_list.go
+++ b/internal/ui/view_dind_process_list.go
@@ -18,7 +18,7 @@ type DindProcessListViewModel struct {
 	selectedDindContainer int
 	showAll               bool
 
-	hostContainer docker.Container
+	hostContainer *docker.Container
 }
 
 // render renders the dind process list view
@@ -70,7 +70,7 @@ func (m *DindProcessListViewModel) render(availableHeight int) string {
 }
 
 // Load switches to the dind process list view and loads containers
-func (m *DindProcessListViewModel) Load(model *Model, hostContainer docker.Container) tea.Cmd {
+func (m *DindProcessListViewModel) Load(model *Model, hostContainer *docker.Container) tea.Cmd {
 	m.hostContainer = hostContainer
 	model.SwitchView(DindProcessListView)
 	return m.DoLoad(model)
@@ -134,7 +134,7 @@ func (m *DindProcessListViewModel) Loaded(containers []models.DockerContainer) {
 	}
 }
 
-func (m *DindProcessListViewModel) GetContainer(model *Model) docker.Container {
+func (m *DindProcessListViewModel) GetContainer(model *Model) *docker.Container {
 	if m.selectedDindContainer < len(m.dindContainers) {
 		container := m.dindContainers[m.selectedDindContainer]
 		return docker.NewDindContainer(model.dockerClient,

--- a/internal/ui/view_docker_container_list.go
+++ b/internal/ui/view_docker_container_list.go
@@ -158,7 +158,7 @@ func (m *DockerContainerListViewModel) HandleShell(model *Model) tea.Cmd {
 	return nil
 }
 
-func (m *DockerContainerListViewModel) GetContainer(model *Model) docker.Container {
+func (m *DockerContainerListViewModel) GetContainer(model *Model) *docker.Container {
 	// Get the selected Docker container
 	if m.selectedDockerContainer < len(m.dockerContainers) {
 		container := m.dockerContainers[m.selectedDockerContainer]

--- a/internal/ui/view_file_browser.go
+++ b/internal/ui/view_file_browser.go
@@ -17,7 +17,7 @@ type FileBrowserViewModel struct {
 	containerFiles    []models.ContainerFile
 	selectedFile      int
 	currentPath       string
-	browsingContainer docker.Container // The container we're browsing
+	browsingContainer *docker.Container // The container we're browsing
 	pathHistory       []string
 }
 
@@ -78,7 +78,7 @@ func (m *FileBrowserViewModel) render(model *Model, availableHeight int) string 
 	return RenderTable(columns, rows, availableHeight-3, m.selectedFile)
 }
 
-func (m *FileBrowserViewModel) LoadContainer(model *Model, container docker.Container) tea.Cmd {
+func (m *FileBrowserViewModel) LoadContainer(model *Model, container *docker.Container) tea.Cmd {
 	m.browsingContainer = container
 	m.pathHistory = []string{}
 	m.pushHistory("/")

--- a/internal/ui/view_file_content.go
+++ b/internal/ui/view_file_content.go
@@ -12,7 +12,7 @@ import (
 )
 
 type FileContentViewModel struct {
-	container   docker.Container
+	container   *docker.Container
 	content     string
 	contentPath string
 	scrollY     int
@@ -31,7 +31,7 @@ func (m *FileContentViewModel) render(model *Model) string {
 	return v.View()
 }
 
-func (m *FileContentViewModel) LoadContainer(model *Model, container docker.Container, path string) tea.Cmd {
+func (m *FileContentViewModel) LoadContainer(model *Model, container *docker.Container, path string) tea.Cmd {
 	model.SwitchView(FileContentView)
 	model.loading = true
 	m.scrollY = 0

--- a/internal/ui/view_top.go
+++ b/internal/ui/view_top.go
@@ -13,7 +13,7 @@ import (
 type TopViewModel struct {
 	content string
 
-	container docker.Container
+	container *docker.Container
 }
 
 // render renders the top view
@@ -39,7 +39,7 @@ func (m *TopViewModel) render(availableHeight int) string {
 }
 
 // Load switches to the top view and loads process info
-func (m *TopViewModel) Load(model *Model, container docker.Container) tea.Cmd {
+func (m *TopViewModel) Load(model *Model, container *docker.Container) tea.Cmd {
 	m.container = container
 	model.SwitchView(TopView)
 	return m.DoLoad(model)

--- a/internal/ui/view_top_test.go
+++ b/internal/ui/view_top_test.go
@@ -150,7 +150,7 @@ root         1  0.0  0.1   4188  3380 ?        Ss   10:00   0:00 /bin/sh`
 func TestTopViewModel_Title(t *testing.T) {
 	tests := []struct {
 		name      string
-		container docker.Container
+		container *docker.Container
 		expected  string
 	}{
 		{


### PR DESCRIPTION
## Summary
- Changed Container from interface to concrete struct with isDind flag
- Created NewContainer and NewDindContainer constructors returning *Container
- Updated all usages throughout codebase to use *Container instead of docker.Container interface
- Fixed all test files to use the new pointer-based approach

## Test plan
- [x] All existing tests pass
- [x] Code compiles without errors
- [x] Manual testing shows application functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)