### PR TITLE
remove unused GenericContainer interface

### DIFF
--- a/internal/models/generic_container.go
+++ b/internal/models/generic_container.go
@@ -1,7 +1,0 @@
-package models
-
-type GenericContainer interface {
-	IsDind() bool
-	GetID() string
-	GetName() string
-}


### PR DESCRIPTION
## Summary
Removed the unused `GenericContainer` interface from `internal/models/generic_container.go`.

## Analysis
- The interface defined three methods: `IsDind()`, `GetID()`, and `GetName()`
- While `ComposeContainer` and `DockerContainer` types implement these methods, the interface itself was never used as a type constraint or referenced anywhere in the codebase
- The interface was purely dead code

## Test plan
- [x] All tests pass after removal
- [x] No compilation errors
- [x] Code formatting passes

Removing dead code to keep the codebase clean and maintainable.

🤖 Generated with [Claude Code](https://claude.ai/code)