### PR TITLE
refactor: use containerOperations for dindListViewHandlers

### DIFF
--- a/internal/ui/keymap.go
+++ b/internal/ui/keymap.go
@@ -78,26 +78,13 @@ func (m *Model) initializeKeyHandlers() {
 	m.logViewKeymap = m.createKeymap(m.logViewHandlers)
 
 	// Dind Process List View
-	m.dindListViewHandlers = []KeyConfig{
+	m.dindListViewHandlers = append([]KeyConfig{
 		{[]string{"up", "k"}, "move up", m.CmdUp},
 		{[]string{"down", "j"}, "move down", m.CmdDown},
 		{[]string{"enter"}, "view logs", m.CmdLog},
-		{[]string{"r"}, "refresh", m.CmdRefresh},
 		{[]string{"esc"}, "back", m.CmdBack},
 		{[]string{"?"}, "help", m.CmdHelp},
-
-		{[]string{"i"}, "inspect", m.CmdInspect},
-		{[]string{"f"}, "browse files", m.CmdFileBrowse},
-		{[]string{"!"}, "exec /bin/sh", m.CmdShell},
-		{[]string{"a"}, "toggle all", m.CmdToggleAll},
-		{[]string{"K"}, "kill", m.CmdKill},
-		{[]string{"S"}, "stop", m.CmdStop},
-		{[]string{"U"}, "start", m.CmdStart},
-		{[]string{"R"}, "restart", m.CmdRestart},
-		{[]string{"P"}, "pause/unpause", m.CmdPause},
-		{[]string{"D"}, "delete", m.CmdDelete},
-		{[]string{"t"}, "top", m.CmdTop},
-	}
+	}, containerOperations...)
 	m.dindListViewKeymap = m.createKeymap(m.dindListViewHandlers)
 
 	// Top View


### PR DESCRIPTION
## Summary
Refactored `dindListViewHandlers` in `keymap.go` to use the shared `containerOperations` array instead of duplicating all container operation key bindings.

## Changes
- Updated `dindListViewHandlers` to use `append()` with `containerOperations` (similar to other container views)
- Removed 13 lines of duplicate key binding definitions
- Maintains exact same functionality with cleaner, DRY code

## Benefits
- **Eliminates code duplication**: All three container views (Docker Container List, Compose Process List, and DinD Process List) now share the same container operations
- **Improves maintainability**: Changes to container operations only need to be made in one place
- **Ensures consistency**: All container views have identical key bindings for common operations

## Test plan
- [x] All tests pass
- [x] No functionality changes, just code organization

🤖 Generated with [Claude Code](https://claude.ai/code)