### PR TITLE
feat: add PageUp/PageDown support to inspect view

### DIFF
--- a/internal/ui/keyhandler_navigation.go
+++ b/internal/ui/keyhandler_navigation.go
@@ -120,6 +120,8 @@ func (m *Model) CmdPageUp(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch m.currentView {
 	case LogView:
 		return m, m.logViewModel.HandlePageUp(m)
+	case InspectView:
+		return m, m.inspectViewModel.HandlePageUp(m)
 	default:
 		slog.Info("PageUp not supported in current view",
 			slog.String("view", m.currentView.String()))
@@ -131,6 +133,8 @@ func (m *Model) CmdPageDown(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch m.currentView {
 	case LogView:
 		return m, m.logViewModel.HandlePageDown(m)
+	case InspectView:
+		return m, m.inspectViewModel.HandlePageDown(m)
 	default:
 		slog.Info("PageDown not supported in current view",
 			slog.String("view", m.currentView.String()))

--- a/internal/ui/keymap.go
+++ b/internal/ui/keymap.go
@@ -179,6 +179,8 @@ func (m *Model) initializeKeyHandlers() {
 	m.inspectViewHandlers = []KeyConfig{
 		{[]string{"up", "k"}, "scroll up", m.CmdUp},
 		{[]string{"down", "j"}, "scroll down", m.CmdDown},
+		{[]string{"pgup"}, "page up", m.CmdPageUp},
+		{[]string{"pgdown", " "}, "page down", m.CmdPageDown},
 		{[]string{"G"}, "go to end", m.CmdGoToEnd},
 		{[]string{"g"}, "go to start", m.CmdGoToStart},
 		{[]string{"/"}, "search", m.CmdSearch},

--- a/internal/ui/view_inspect.go
+++ b/internal/ui/view_inspect.go
@@ -299,6 +299,29 @@ func (m *InspectViewModel) HandleGoToStart() tea.Cmd {
 	return nil
 }
 
+func (m *InspectViewModel) HandlePageUp(model *Model) tea.Cmd {
+	pageSize := model.Height - 5
+	m.inspectScrollY -= pageSize
+	if m.inspectScrollY < 0 {
+		m.inspectScrollY = 0
+	}
+	return nil
+}
+
+func (m *InspectViewModel) HandlePageDown(model *Model) tea.Cmd {
+	pageSize := model.Height - 5
+	lines := strings.Split(m.inspectContent, "\n")
+	maxScroll := len(lines) - pageSize
+
+	m.inspectScrollY += pageSize
+	if m.inspectScrollY > maxScroll && maxScroll > 0 {
+		m.inspectScrollY = maxScroll
+	} else if maxScroll <= 0 {
+		m.inspectScrollY = 0
+	}
+	return nil
+}
+
 func (m *InspectViewModel) HandleSearch() tea.Cmd {
 	m.ClearSearch()
 	return nil


### PR DESCRIPTION
## Summary
Added PageUp and PageDown functionality to the inspect view for faster navigation through container/image/network/volume inspect output.

## Changes
- Added `HandlePageUp` and `HandlePageDown` methods to `InspectViewModel` 
- Updated `CmdPageUp` and `CmdPageDown` in `keyhandler_navigation.go` to include `InspectView`
- Added keybindings for `pgup`, `pgdown`, and `Space` (as PageDown) in inspect view keymap

## Implementation Details
- Page size is calculated as `(window height - 5)` to account for UI chrome
- Properly handles boundary checking to prevent scrolling past the beginning or end
- Space key acts as PageDown (common terminal convention)
- Mirrors the implementation used in log view for consistency

## Test plan
- [x] All existing tests pass
- [x] Code formatting passes
- [x] Manual testing shows PageUp/PageDown work correctly in inspect view

This completes the PageUp/PageDown support across both log and inspect views, improving navigation for users viewing large outputs.

🤖 Generated with [Claude Code](https://claude.ai/code)