### PR TITLE
feat: add command action selector view for Docker containers

### DIFF
--- a/internal/ui/keyhandler_navigation.go
+++ b/internal/ui/keyhandler_navigation.go
@@ -36,6 +36,8 @@ func (m *Model) CmdUp(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, m.composeProcessListViewModel.HandleUp()
 	case CommandExecutionView:
 		return m, m.commandExecutionViewModel.HandleUp()
+	case CommandActionView:
+		return m, m.commandActionViewModel.HandleUp()
 	default:
 		slog.Info("Unhandled key up in current view",
 			slog.String("view", m.currentView.String()))
@@ -75,6 +77,8 @@ func (m *Model) CmdDown(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, m.composeProcessListViewModel.HandleDown()
 	case CommandExecutionView:
 		return m, m.commandExecutionViewModel.HandleDown(m)
+	case CommandActionView:
+		return m, m.commandActionViewModel.HandleDown()
 	default:
 		slog.Info("Unhandled key down in current view",
 			slog.String("view", m.currentView.String()))
@@ -170,6 +174,8 @@ func (m *Model) CmdBack(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, m.volumeListViewModel.HandleBack(m)
 	case CommandExecutionView:
 		return m, m.commandExecutionViewModel.HandleBack(m)
+	case CommandActionView:
+		return m, m.commandActionViewModel.HandleBack(m)
 	case ComposeProcessListView:
 		// Should not happen in ComposeProcessListView, but handle it gracefully
 		// This is the main view, nowhere to go back to

--- a/internal/ui/keyhandler_views.go
+++ b/internal/ui/keyhandler_views.go
@@ -45,3 +45,21 @@ func (m *Model) CmdShell(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 }
+
+func (m *Model) CmdShowActions(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch m.currentView {
+	case DockerContainerListView:
+		return m, m.dockerContainerListViewModel.HandleShowActions(m)
+	default:
+		return m, nil
+	}
+}
+
+func (m *Model) CmdSelectAction(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch m.currentView {
+	case CommandActionView:
+		return m, m.commandActionViewModel.HandleSelect(m)
+	default:
+		return m, nil
+	}
+}

--- a/internal/ui/keymap.go
+++ b/internal/ui/keymap.go
@@ -40,6 +40,7 @@ func (m *Model) initializeKeyHandlers() {
 		{[]string{"up", "k"}, "move up", m.CmdUp},
 		{[]string{"down", "j"}, "move down", m.CmdDown},
 		{[]string{"enter"}, "view logs", m.CmdLog},
+		{[]string{"x"}, "show actions", m.CmdShowActions},
 		{[]string{"esc"}, "back", m.CmdBack},
 		{[]string{"?"}, "help", m.CmdHelp},
 
@@ -210,6 +211,16 @@ func (m *Model) initializeKeyHandlers() {
 		{[]string{"?"}, "help", m.CmdHelp},
 	}
 	m.commandExecKeymap = m.createKeymap(m.commandExecHandlers)
+
+	// Command Action View
+	m.commandActionHandlers = []KeyConfig{
+		{[]string{"up", "k"}, "move up", m.CmdUp},
+		{[]string{"down", "j"}, "move down", m.CmdDown},
+		{[]string{"enter"}, "execute action", m.CmdSelectAction},
+		{[]string{"esc"}, "cancel", m.CmdBack},
+		{[]string{"?"}, "help", m.CmdHelp},
+	}
+	m.commandActionKeymap = m.createKeymap(m.commandActionHandlers)
 
 	// Initialize command registry
 	m.initCommandRegistry()

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -30,6 +30,7 @@ const (
 	InspectView
 	HelpView
 	CommandExecutionView
+	CommandActionView
 )
 
 // UI Chrome offsets for different views
@@ -71,6 +72,8 @@ func (view ViewType) String() string {
 		return "Help"
 	case CommandExecutionView:
 		return "Command Execution"
+	case CommandActionView:
+		return "Command Actions"
 	default:
 		return "Unknown View"
 	}
@@ -88,6 +91,7 @@ type Model struct {
 	dockerContainerListViewModel DockerContainerListViewModel
 	logViewModel                 LogViewModel
 	commandExecutionViewModel    CommandExecutionViewModel
+	commandActionViewModel       CommandActionViewModel
 	fileBrowserViewModel         FileBrowserViewModel
 	inspectViewModel             InspectViewModel
 	composeProjectListViewModel  ComposeProjectListViewModel
@@ -145,6 +149,8 @@ type Model struct {
 	helpViewHandlers                []KeyConfig
 	commandExecKeymap               map[string]KeyHandler
 	commandExecHandlers             []KeyConfig
+	commandActionKeymap             map[string]KeyHandler
+	commandActionHandlers           []KeyConfig
 
 	// Command-line mode state
 	commandViewModel CommandViewModel
@@ -263,6 +269,8 @@ func (m *Model) GetCurrentViewModel() interface{} {
 		return &m.helpViewModel
 	case CommandExecutionView:
 		return &m.commandExecutionViewModel
+	case CommandActionView:
+		return &m.commandActionViewModel
 	default:
 		slog.Error("GetCurrentViewModel called with unknown view",
 			slog.String("view", m.currentView.String()))
@@ -303,6 +311,8 @@ func (m *Model) GetViewKeyHandlers(view ViewType) []KeyConfig {
 		return m.helpViewHandlers
 	case CommandExecutionView:
 		return m.commandExecHandlers
+	case CommandActionView:
+		return m.commandActionHandlers
 	default:
 		return nil
 	}
@@ -341,6 +351,8 @@ func (m *Model) GetViewKeymap(view ViewType) map[string]KeyHandler {
 		return m.helpViewKeymap
 	case CommandExecutionView:
 		return m.commandExecKeymap
+	case CommandActionView:
+		return m.commandActionKeymap
 	default:
 		return nil
 	}

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -273,6 +273,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case CommandExecutionView:
 			// Command execution is already running, no refresh needed
 			return m, nil
+		case CommandActionView:
+			// Action view doesn't need refresh
+			return m, nil
 		default:
 			m.loading = false
 			return m, nil

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -135,6 +135,8 @@ func (m *Model) viewTitle() string {
 		return fmt.Sprintf("Help for %s", headerStyle.Render(m.helpViewModel.parentView.String()))
 	case CommandExecutionView:
 		return "Command Execution"
+	case CommandActionView:
+		return "Select Action"
 	default:
 		return "Unknown View"
 	}
@@ -182,6 +184,8 @@ func (m *Model) viewBody(availableHeight int) string {
 		return m.helpViewModel.render(m, availableHeight)
 	case CommandExecutionView:
 		return m.commandExecutionViewModel.render(m)
+	case CommandActionView:
+		return m.commandActionViewModel.render(m)
 	default:
 		return "Unknown view"
 	}

--- a/internal/ui/view_command_action.go
+++ b/internal/ui/view_command_action.go
@@ -1,0 +1,245 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/tokuhirom/dcv/internal/docker"
+)
+
+// CommandAction represents a container operation
+type CommandAction struct {
+	Key         string
+	Name        string
+	Description string
+	Aggressive  bool
+	Handler     func(m *Model, container *docker.Container) tea.Cmd
+}
+
+// CommandActionViewModel manages the command action selection view
+type CommandActionViewModel struct {
+	actions         []CommandAction
+	selectedAction  int
+	targetContainer *docker.Container
+}
+
+// Initialize sets up the action view with available commands for a container
+func (m *CommandActionViewModel) Initialize(container *docker.Container) {
+	m.targetContainer = container
+	m.selectedAction = 0
+
+	// Define available actions based on container state
+	m.actions = []CommandAction{}
+
+	// Always available actions
+	m.actions = append(m.actions, CommandAction{
+		Key:         "Enter",
+		Name:        "View Logs",
+		Description: "Show container logs",
+		Aggressive:  false,
+		Handler: func(model *Model, c *docker.Container) tea.Cmd {
+			return model.dockerContainerListViewModel.HandleViewLog(model)
+		},
+	})
+
+	m.actions = append(m.actions, CommandAction{
+		Key:         "I",
+		Name:        "Inspect",
+		Description: "View container configuration",
+		Aggressive:  false,
+		Handler: func(model *Model, c *docker.Container) tea.Cmd {
+			return model.dockerContainerListViewModel.HandleInspect(model)
+		},
+	})
+
+	m.actions = append(m.actions, CommandAction{
+		Key:         "f",
+		Name:        "Browse Files",
+		Description: "Browse container filesystem",
+		Aggressive:  false,
+		Handler: func(model *Model, c *docker.Container) tea.Cmd {
+			return model.dockerContainerListViewModel.HandleFileBrowse(model)
+		},
+	})
+
+	m.actions = append(m.actions, CommandAction{
+		Key:         "!",
+		Name:        "Execute Shell",
+		Description: "Execute /bin/sh in container",
+		Aggressive:  false,
+		Handler: func(model *Model, c *docker.Container) tea.Cmd {
+			return model.dockerContainerListViewModel.HandleShell(model)
+		},
+	})
+
+	// State-dependent actions
+	if container.GetState() == "running" {
+		m.actions = append(m.actions, CommandAction{
+			Key:         "S",
+			Name:        "Stop",
+			Description: "Stop the container",
+			Aggressive:  true,
+			Handler: func(model *Model, c *docker.Container) tea.Cmd {
+				return model.dockerContainerListViewModel.HandleStop(model)
+			},
+		})
+
+		m.actions = append(m.actions, CommandAction{
+			Key:         "R",
+			Name:        "Restart",
+			Description: "Restart the container",
+			Aggressive:  true,
+			Handler: func(model *Model, c *docker.Container) tea.Cmd {
+				return model.dockerContainerListViewModel.HandleRestart(model)
+			},
+		})
+
+		m.actions = append(m.actions, CommandAction{
+			Key:         "K",
+			Name:        "Kill",
+			Description: "Force kill the container",
+			Aggressive:  true,
+			Handler: func(model *Model, c *docker.Container) tea.Cmd {
+				return model.dockerContainerListViewModel.HandleKill(model)
+			},
+		})
+
+		m.actions = append(m.actions, CommandAction{
+			Key:         "P",
+			Name:        "Pause",
+			Description: "Pause the container",
+			Aggressive:  true,
+			Handler: func(model *Model, c *docker.Container) tea.Cmd {
+				return model.dockerContainerListViewModel.HandlePause(model)
+			},
+		})
+	} else if container.GetState() == "paused" {
+		m.actions = append(m.actions, CommandAction{
+			Key:         "P",
+			Name:        "Unpause",
+			Description: "Resume the container",
+			Aggressive:  true,
+			Handler: func(model *Model, c *docker.Container) tea.Cmd {
+				return model.dockerContainerListViewModel.HandlePause(model)
+			},
+		})
+	} else if container.GetState() == "exited" || container.GetState() == "created" {
+		m.actions = append(m.actions, CommandAction{
+			Key:         "U",
+			Name:        "Start",
+			Description: "Start the container",
+			Aggressive:  false,
+			Handler: func(model *Model, c *docker.Container) tea.Cmd {
+				return model.dockerContainerListViewModel.HandleStart(model)
+			},
+		})
+
+		m.actions = append(m.actions, CommandAction{
+			Key:         "D",
+			Name:        "Delete",
+			Description: "Remove the container",
+			Aggressive:  true,
+			Handler: func(model *Model, c *docker.Container) tea.Cmd {
+				return model.dockerContainerListViewModel.HandleDelete(model)
+			},
+		})
+	}
+}
+
+// render displays the action selection menu
+func (m *CommandActionViewModel) render(model *Model) string {
+	if m.targetContainer == nil {
+		return "No container selected"
+	}
+
+	var s strings.Builder
+
+	// Header
+	headerStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("7")).
+		Background(lipgloss.Color("4")).
+		Width(model.width).
+		Padding(0, 1)
+
+	header := fmt.Sprintf("Select Action for %s", m.targetContainer.GetName())
+	s.WriteString(headerStyle.Render(header))
+	s.WriteString("\n\n")
+
+	// Container info
+	infoStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+	s.WriteString(infoStyle.Render(fmt.Sprintf("Container: %s\n", m.targetContainer.GetName())))
+	s.WriteString(infoStyle.Render(fmt.Sprintf("State: %s\n", m.targetContainer.GetState())))
+	s.WriteString("\n")
+
+	// Actions list
+	s.WriteString("Available Actions:\n\n")
+
+	for i, action := range m.actions {
+		prefix := "  "
+		if i == m.selectedAction {
+			prefix = "> "
+		}
+
+		// Color based on aggressive flag
+		var actionStyle lipgloss.Style
+		if action.Aggressive {
+			actionStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("1")) // Red for aggressive
+		} else {
+			actionStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("2")) // Green for safe
+		}
+
+		if i == m.selectedAction {
+			actionStyle = actionStyle.Bold(true).Background(lipgloss.Color("237"))
+		}
+
+		line := fmt.Sprintf("%s[%s] %s - %s", prefix, action.Key, action.Name, action.Description)
+		s.WriteString(actionStyle.Render(line))
+		s.WriteString("\n")
+	}
+
+	// Footer
+	s.WriteString("\n")
+	footerStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+	s.WriteString(footerStyle.Render("Use ↑/↓ to select, Enter to execute, Esc to cancel"))
+
+	return s.String()
+}
+
+// HandleUp moves selection up
+func (m *CommandActionViewModel) HandleUp() tea.Cmd {
+	if m.selectedAction > 0 {
+		m.selectedAction--
+	}
+	return nil
+}
+
+// HandleDown moves selection down
+func (m *CommandActionViewModel) HandleDown() tea.Cmd {
+	if m.selectedAction < len(m.actions)-1 {
+		m.selectedAction++
+	}
+	return nil
+}
+
+// HandleSelect executes the selected action
+func (m *CommandActionViewModel) HandleSelect(model *Model) tea.Cmd {
+	if m.selectedAction >= 0 && m.selectedAction < len(m.actions) {
+		action := m.actions[m.selectedAction]
+		// Remove CommandActionView from history by going back
+		model.SwitchToPreviousView()
+		// Now when the command execution view shows and user presses ESC,
+		// they'll go back to the container list, not the action view
+		return action.Handler(model, m.targetContainer)
+	}
+	return nil
+}
+
+// HandleBack returns to the previous view
+func (m *CommandActionViewModel) HandleBack(model *Model) tea.Cmd {
+	model.SwitchToPreviousView()
+	return nil
+}

--- a/internal/ui/view_docker_container_list.go
+++ b/internal/ui/view_docker_container_list.go
@@ -217,3 +217,59 @@ func (m *DockerContainerListViewModel) HandleDindProcessList(model *Model) tea.C
 
 	return model.dindProcessListViewModel.Load(model, container)
 }
+
+func (m *DockerContainerListViewModel) HandleViewLog(model *Model) tea.Cmd {
+	return m.HandleLog(model)
+}
+
+func (m *DockerContainerListViewModel) HandleStop(model *Model) tea.Cmd {
+	if m.selectedDockerContainer < len(m.dockerContainers) {
+		container := m.dockerContainers[m.selectedDockerContainer]
+		return model.commandExecutionViewModel.ExecuteCommand(model, true, "stop", container.ID)
+	}
+	return nil
+}
+
+func (m *DockerContainerListViewModel) HandleStart(model *Model) tea.Cmd {
+	if m.selectedDockerContainer < len(m.dockerContainers) {
+		container := m.dockerContainers[m.selectedDockerContainer]
+		return model.commandExecutionViewModel.ExecuteCommand(model, false, "start", container.ID)
+	}
+	return nil
+}
+
+func (m *DockerContainerListViewModel) HandleRestart(model *Model) tea.Cmd {
+	if m.selectedDockerContainer < len(m.dockerContainers) {
+		container := m.dockerContainers[m.selectedDockerContainer]
+		return model.commandExecutionViewModel.ExecuteCommand(model, true, "restart", container.ID)
+	}
+	return nil
+}
+
+func (m *DockerContainerListViewModel) HandlePause(model *Model) tea.Cmd {
+	if m.selectedDockerContainer < len(m.dockerContainers) {
+		container := m.dockerContainers[m.selectedDockerContainer]
+		if container.State == "paused" {
+			return model.commandExecutionViewModel.ExecuteCommand(model, true, "unpause", container.ID)
+		}
+		return model.commandExecutionViewModel.ExecuteCommand(model, true, "pause", container.ID)
+	}
+	return nil
+}
+
+func (m *DockerContainerListViewModel) HandleDelete(model *Model) tea.Cmd {
+	return m.HandleRemove(model)
+}
+
+func (m *DockerContainerListViewModel) HandleShowActions(model *Model) tea.Cmd {
+	container := m.GetContainer(model)
+	if container == nil {
+		slog.Error("Failed to get selected container for actions")
+		return nil
+	}
+
+	// Initialize the action view with the selected container
+	model.commandActionViewModel.Initialize(container)
+	model.SwitchView(CommandActionView)
+	return nil
+}


### PR DESCRIPTION
## Summary
- Added a new CommandActionView that displays available container operations when pressing 'x' key
- Provides an intuitive menu-driven interface for container operations
- Ensures proper view history management so ESC returns to container list, not action view

## Details

This PR introduces a new CommandActionView that provides a user-friendly action selector for Docker containers. When users press 'x' in the DockerContainerListView, they get a menu of available operations for the selected container.

### Key Features:
- **Dynamic action list**: Actions are shown based on container state (running, paused, exited)
- **Color-coded operations**: Red for aggressive operations (stop, kill, delete), green for safe operations
- **Proper navigation flow**: When selecting an action that shows CommandExecutionView and user presses ESC, they return to the container list instead of the action view
- **Vim-style navigation**: Use j/k or arrow keys to navigate, Enter to select, ESC to cancel

### Implementation Details:
- Created new `view_command_action.go` with complete view model implementation
- Added 'x' key handler to DockerContainerListView keymap
- Integrated with existing command execution handlers
- Added wrapper methods in DockerContainerListView for all container operations
- Proper view history management to ensure correct ESC behavior

## Test Plan
- [x] All existing tests pass
- [x] Code formatted with `make fmt`
- [x] Manual testing of action selector:
  - Press 'x' in DockerContainerListView
  - Navigate through available actions
  - Select an action and verify execution
  - Press ESC from command execution to verify return to container list

🤖 Generated with [Claude Code](https://claude.ai/code)