### PR TITLE
refactor: enable command action selector for all container views

### DIFF
--- a/internal/ui/keyhandler_views.go
+++ b/internal/ui/keyhandler_views.go
@@ -48,8 +48,12 @@ func (m *Model) CmdShell(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 func (m *Model) CmdShowActions(_ tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch m.currentView {
+	case ComposeProcessListView:
+		return m, m.composeProcessListViewModel.HandleShowActions(m)
 	case DockerContainerListView:
 		return m, m.dockerContainerListViewModel.HandleShowActions(m)
+	case DindProcessListView:
+		return m, m.dindProcessListViewModel.HandleShowActions(m)
 	default:
 		return m, nil
 	}

--- a/internal/ui/keymap.go
+++ b/internal/ui/keymap.go
@@ -20,6 +20,7 @@ func (m *Model) initializeKeyHandlers() {
 
 	// TODO: support following commands in dind view
 	containerOperations := []KeyConfig{
+		{[]string{"x"}, "show actions", m.CmdShowActions},
 		{[]string{"f"}, "browse files", m.CmdFileBrowse},
 		{[]string{"!"}, "exec /bin/sh", m.CmdShell},
 		{[]string{"i"}, "inspect", m.CmdInspect},
@@ -40,7 +41,6 @@ func (m *Model) initializeKeyHandlers() {
 		{[]string{"up", "k"}, "move up", m.CmdUp},
 		{[]string{"down", "j"}, "move down", m.CmdDown},
 		{[]string{"enter"}, "view logs", m.CmdLog},
-		{[]string{"x"}, "show actions", m.CmdShowActions},
 		{[]string{"esc"}, "back", m.CmdBack},
 		{[]string{"?"}, "help", m.CmdHelp},
 

--- a/internal/ui/view_compose_process_list.go
+++ b/internal/ui/view_compose_process_list.go
@@ -181,6 +181,53 @@ func (m *ComposeProcessListViewModel) HandleRemove(model *Model) tea.Cmd {
 	return nil
 }
 
+func (m *ComposeProcessListViewModel) HandleStop(model *Model) tea.Cmd {
+	if m.selectedContainer < len(m.composeContainers) {
+		container := m.composeContainers[m.selectedContainer]
+		return model.commandExecutionViewModel.ExecuteCommand(model, true, "stop", container.ID)
+	}
+	return nil
+}
+
+func (m *ComposeProcessListViewModel) HandleStart(model *Model) tea.Cmd {
+	if m.selectedContainer < len(m.composeContainers) {
+		container := m.composeContainers[m.selectedContainer]
+		return model.commandExecutionViewModel.ExecuteCommand(model, false, "start", container.ID)
+	}
+	return nil
+}
+
+func (m *ComposeProcessListViewModel) HandleRestart(model *Model) tea.Cmd {
+	if m.selectedContainer < len(m.composeContainers) {
+		container := m.composeContainers[m.selectedContainer]
+		return model.commandExecutionViewModel.ExecuteCommand(model, true, "restart", container.ID)
+	}
+	return nil
+}
+
+func (m *ComposeProcessListViewModel) HandleKill(model *Model) tea.Cmd {
+	if m.selectedContainer < len(m.composeContainers) {
+		container := m.composeContainers[m.selectedContainer]
+		return model.commandExecutionViewModel.ExecuteCommand(model, true, "kill", container.ID)
+	}
+	return nil
+}
+
+func (m *ComposeProcessListViewModel) HandlePause(model *Model) tea.Cmd {
+	if m.selectedContainer < len(m.composeContainers) {
+		container := m.composeContainers[m.selectedContainer]
+		if container.State == "paused" {
+			return model.commandExecutionViewModel.ExecuteCommand(model, true, "unpause", container.ID)
+		}
+		return model.commandExecutionViewModel.ExecuteCommand(model, true, "pause", container.ID)
+	}
+	return nil
+}
+
+func (m *ComposeProcessListViewModel) HandleDelete(model *Model) tea.Cmd {
+	return m.HandleRemove(model)
+}
+
 func (m *ComposeProcessListViewModel) HandleFileBrowse(model *Model) tea.Cmd {
 	container := m.GetContainer(model)
 	if container != nil {
@@ -229,6 +276,19 @@ func (m *ComposeProcessListViewModel) HandleInspect(model *Model) tea.Cmd {
 
 func (m *ComposeProcessListViewModel) HandleBack(model *Model) tea.Cmd {
 	model.SwitchToPreviousView()
+	return nil
+}
+
+func (m *ComposeProcessListViewModel) HandleShowActions(model *Model) tea.Cmd {
+	container := m.GetContainer(model)
+	if container == nil {
+		slog.Error("Failed to get selected container for actions")
+		return nil
+	}
+
+	// Initialize the action view with the selected container
+	model.commandActionViewModel.Initialize(container, ComposeProcessListView)
+	model.SwitchView(CommandActionView)
 	return nil
 }
 

--- a/internal/ui/view_dind_process_list.go
+++ b/internal/ui/view_dind_process_list.go
@@ -174,6 +174,67 @@ func (m *DindProcessListViewModel) HandleDelete(model *Model) tea.Cmd {
 	return model.commandExecutionViewModel.ExecuteCommand(model, true, args...) // rm is aggressive
 }
 
+func (m *DindProcessListViewModel) HandleStop(model *Model) tea.Cmd {
+	container := m.GetContainer(model)
+	if container == nil {
+		slog.Error("Failed to get selected container for stop")
+		return nil
+	}
+
+	args := container.OperationArgs("stop")
+	return model.commandExecutionViewModel.ExecuteCommand(model, true, args...)
+}
+
+func (m *DindProcessListViewModel) HandleStart(model *Model) tea.Cmd {
+	container := m.GetContainer(model)
+	if container == nil {
+		slog.Error("Failed to get selected container for start")
+		return nil
+	}
+
+	args := container.OperationArgs("start")
+	return model.commandExecutionViewModel.ExecuteCommand(model, false, args...)
+}
+
+func (m *DindProcessListViewModel) HandleRestart(model *Model) tea.Cmd {
+	container := m.GetContainer(model)
+	if container == nil {
+		slog.Error("Failed to get selected container for restart")
+		return nil
+	}
+
+	args := container.OperationArgs("restart")
+	return model.commandExecutionViewModel.ExecuteCommand(model, true, args...)
+}
+
+func (m *DindProcessListViewModel) HandleKill(model *Model) tea.Cmd {
+	container := m.GetContainer(model)
+	if container == nil {
+		slog.Error("Failed to get selected container for kill")
+		return nil
+	}
+
+	args := container.OperationArgs("kill")
+	return model.commandExecutionViewModel.ExecuteCommand(model, true, args...)
+}
+
+func (m *DindProcessListViewModel) HandlePause(model *Model) tea.Cmd {
+	container := m.GetContainer(model)
+	if container == nil {
+		slog.Error("Failed to get selected container for pause")
+		return nil
+	}
+
+	var cmd string
+	if container.GetState() == "paused" {
+		cmd = "unpause"
+	} else {
+		cmd = "pause"
+	}
+	args := container.OperationArgs(cmd)
+	return model.commandExecutionViewModel.ExecuteCommand(model, true, args...)
+}
+
 func (m *DindProcessListViewModel) HandleShell(model *Model) tea.Cmd {
 	if m.selectedDindContainer >= len(m.dindContainers) {
 		return nil
@@ -198,6 +259,19 @@ func (m *DindProcessListViewModel) HandleFileBrowse(model *Model) tea.Cmd {
 	}
 	slog.Error("Failed to get selected container for file browser",
 		slog.Any("error", fmt.Errorf("no container selected")))
+	return nil
+}
+
+func (m *DindProcessListViewModel) HandleShowActions(model *Model) tea.Cmd {
+	container := m.GetContainer(model)
+	if container == nil {
+		slog.Error("Failed to get selected container for actions")
+		return nil
+	}
+
+	// Initialize the action view with the selected container
+	model.commandActionViewModel.Initialize(container, DindProcessListView)
+	model.SwitchView(CommandActionView)
 	return nil
 }
 

--- a/internal/ui/view_docker_container_list.go
+++ b/internal/ui/view_docker_container_list.go
@@ -269,7 +269,7 @@ func (m *DockerContainerListViewModel) HandleShowActions(model *Model) tea.Cmd {
 	}
 
 	// Initialize the action view with the selected container
-	model.commandActionViewModel.Initialize(container)
+	model.commandActionViewModel.Initialize(container, DockerContainerListView)
 	model.SwitchView(CommandActionView)
 	return nil
 }


### PR DESCRIPTION
## Summary
- Moved 'x' key handler to shared containerOperations, making it available in all container views
- Added support for command action selector in ComposeProcessListView and DindProcessListView
- Refactored CommandActionView to track origin view and use appropriate handlers

## Details

This PR extends the command action selector functionality (introduced in #189) to all container views, not just DockerContainerListView.

### Changes Made:
1. **Moved 'x' key to shared containerOperations** - Now available in ComposeProcessListView, DockerContainerListView, and DindProcessListView
2. **Added HandleShowActions methods** to ComposeProcessListView and DindProcessListView
3. **Enhanced CommandActionViewModel** to track which view it originated from
4. **Added missing container operation handlers** to ensure consistency across all views
5. **Refactored handler selection** to dynamically choose appropriate handlers based on origin view

### Technical Details:
- CommandActionViewModel now stores `originView` to track where it was launched from
- Helper methods in CommandActionView route to the correct view model handlers
- Added comprehensive handler methods (Stop, Start, Restart, Kill, Pause, Delete) to ComposeProcessListView and DindProcessListView for consistency

## Test Plan
- [x] All existing tests pass
- [x] Code formatted with `make fmt`
- [x] Manual testing:
  - Press 'x' in ComposeProcessListView - action menu appears
  - Press 'x' in DockerContainerListView - action menu appears
  - Press 'x' in DindProcessListView - action menu appears
  - Actions execute correctly from all views
  - ESC navigation works properly

🤖 Generated with [Claude Code](https://claude.ai/code)