### PR TITLE
fix: automatically reload list when returning from CommandExecutionView

### DIFF
--- a/internal/ui/view_command_execution.go
+++ b/internal/ui/view_command_execution.go
@@ -153,7 +153,11 @@ func (m *CommandExecutionViewModel) HandleBack(model *Model) tea.Cmd {
 
 	// Go back to previous view
 	model.SwitchToPreviousView()
-	return nil
+
+	// Trigger a refresh to reload the list with updated state
+	return func() tea.Msg {
+		return RefreshMsg{}
+	}
 }
 
 func (m *CommandExecutionViewModel) ExecuteCommand(model *Model, aggressive bool, args ...string) tea.Cmd {

--- a/internal/ui/view_command_execution_test.go
+++ b/internal/ui/view_command_execution_test.go
@@ -106,3 +106,30 @@ func TestCommandExecutionViewModel_RenderConfirmationDialog(t *testing.T) {
 	assert.Contains(t, result, "docker stop container_id")
 	assert.Contains(t, result, "Press 'y' to confirm, 'n' to cancel")
 }
+
+func TestCommandExecutionViewModel_HandleBack(t *testing.T) {
+	t.Run("returns RefreshMsg when going back", func(t *testing.T) {
+		model := &Model{
+			currentView: CommandExecutionView,
+			viewHistory: []ViewType{ComposeProcessListView, CommandExecutionView},
+		}
+		vm := &CommandExecutionViewModel{
+			done:     true,
+			exitCode: 0,
+		}
+		model.commandExecutionViewModel = *vm
+
+		cmd := vm.HandleBack(model)
+
+		// Should switch to previous view
+		assert.Equal(t, ComposeProcessListView, model.currentView)
+
+		// Should return a command that generates RefreshMsg
+		assert.NotNil(t, cmd, "Should return a command to trigger refresh")
+
+		// Execute the command to verify it returns RefreshMsg
+		msg := cmd()
+		_, isRefreshMsg := msg.(RefreshMsg)
+		assert.True(t, isRefreshMsg, "Command should return RefreshMsg")
+	})
+}


### PR DESCRIPTION
## Summary
Fixes issue #166 where container lists were not being automatically reloaded when returning from command execution.

## Problem
When a user executed a container operation (like stop, start, restart, kill, delete, etc.) through the CommandExecutionView and then pressed ESC to return to the container list, the list would show stale data and wouldn't reflect the changes made by the command.

## Solution
Modified the `HandleBack()` method in `CommandExecutionViewModel` to return a `RefreshMsg` when returning to the previous view. This triggers the existing refresh mechanism that reloads the appropriate list based on the current view (ComposeProcessListView, DockerContainerListView, or DindProcessListView).

## Changes
- **Modified** `internal/ui/view_command_execution.go`:
  - Updated `HandleBack()` to return `RefreshMsg` after switching to previous view
- **Added** test in `internal/ui/view_command_execution_test.go`:
  - Verifies that `HandleBack()` returns a command that generates `RefreshMsg`

## Testing
- All existing tests pass
- New test verifies the refresh behavior
- The fix applies to all container views that use CommandExecutionView

Fixes #166

🤖 Generated with [Claude Code](https://claude.ai/code)