### PR TITLE
docs: simplify README by linking to keymap documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,164 +32,47 @@ DCV (Docker Container Viewer) is a TUI tool for monitoring Docker containers and
 
 ## Key Views
 
+For a complete list of keyboard shortcuts and commands in each view, see [docs/keymap.md](docs/keymap.md).
+
 1. **Docker Container List View**: Shows `docker ps` results for all containers
-   - `↑`/`k`: Move up
-   - `↓`/`j`: Move down
-   - `Enter`: View container logs
-   - `f`: Browse container files
-   - `!`: Execute /bin/sh in container
-   - `I`: Inspect container (view full config)
-   - `a`: Toggle show all containers (including stopped)
-   - `K`: Kill container (with confirmation)
-   - `S`: Stop container (with confirmation)
-   - `U`: Start container (with confirmation)
-   - `R`: Restart container (with confirmation)
-   - `P`: Pause/Unpause container (with confirmation)
-   - `D`: Delete stopped container (with confirmation)
-   - `r`: Refresh list
-   - `?`: Show help view
-   - `:`: Enter command mode
-   - `q`/`Esc`: Back to Docker Compose view
 
 2. **Docker Compose Process List View**: Shows `docker compose ps` results
-   - `↑`/`k`: Move up
-   - `↓`/`j`: Move down
-   - `Enter`: View container logs
-   - `d`: Navigate to dind process list (for dind containers)
-   - `f`: Browse container files
-   - `!`: Execute /bin/sh in container
-   - `I`: Inspect container (view full config)
-   - `p`: Switch to Docker container list view
-   - `i`: Switch to Docker image list view
-   - `n`: Switch to Docker network list view
-   - `P`: Switch to project list view
-   - `a`: Toggle show all containers (including stopped)
-   - `t`: Show process info (docker compose top)
-   - `s`: Show container stats
-   - `K`: Kill service (with confirmation)
-   - `S`: Stop service (with confirmation)
-   - `U`: Start service (with confirmation)
-   - `R`: Restart service (with confirmation)
-   - `P`: Pause/Unpause container (with confirmation)
-   - `D`: Delete stopped container (with confirmation)
-   - `u`: Deploy all services (docker compose up -d)
-   - `x`: Stop and remove all services (docker compose down - with confirmation)
-   - `r`: Refresh list
-   - `?`: Show help view
-   - `:`: Enter command mode
-   - `q`: Quit (with confirmation)
 
 3. **Image List View**: Shows Docker images with repository, tag, ID, creation time, and size
-   - `↑`/`k`: Move up
-   - `↓`/`j`: Move down
-   - `I`: Inspect image (view full config)
-   - `a`: Toggle show all images (including intermediate layers)
-   - `r`: Refresh list
-   - `D`: Remove selected image (with confirmation)
-   - `F`: Force remove selected image (even if used by containers - with confirmation)
-   - `Esc`/`q`: Back to Docker Compose process list
 
 4. **Project List View**: Shows all Docker Compose projects
-   - `↑`/`k`: Move up
-   - `↓`/`j`: Move down
-   - `Enter`: Select project and view its containers
-   - `r`: Refresh list
-   - `q`: Quit
 
 5. **Dind Process List View**: Executes `docker ps` inside selected dind containers
-   - `↑`/`k`: Move up
-   - `↓`/`j`: Move down
-   - `Enter`: View logs of containers running inside dind
-   - `r`: Refresh list
-   - `Esc`/`q`: Back to process list
 
 6. **Log View**: Displays container logs with vim-like navigation
-   - `↑`/`k`: Scroll up
-   - `↓`/`j`: Scroll down
-   - `G`: Jump to end
-   - `g`: Jump to start
-   - `/`: Search logs (highlights matches in all logs)
-   - `f`: Filter logs (shows only lines matching the filter)
-   - `n`: Next search result
-   - `N`: Previous search result
-   - `?`: Show help view
-   - `Esc`/`q`: Back to previous view
+   - Supports search (`/`) and filter (`f`) functionality
+   - Search highlights matches in all logs
+   - Filter shows only lines matching the filter
 
 7. **Top View**: Shows process information (docker compose top)
-   - `r`: Refresh
-   - `?`: Show help view
-   - `Esc`/`q`: Back to process list
 
 8. **Stats View**: Shows container resource usage statistics
-   - `r`: Refresh
-   - `?`: Show help view
-   - `Esc`/`q`: Back to process list
 
 9. **Network List View**: Shows Docker networks with ID, name, driver, scope, and container count
-   - `↑`/`k`: Move up
-   - `↓`/`j`: Move down
-   - `Enter`: Inspect network (view full config)
-   - `r`: Refresh list
-   - `D`: Remove selected network (except default networks - with confirmation)
-   - `Esc`/`q`: Back to Docker Compose process list
 
 10. **Volume List View**: Shows Docker volumes with name, driver, scope
-    - `↑`/`k`: Move up
-    - `↓`/`j`: Move down
-    - `Enter`: Inspect volume (view full config)
-    - `r`: Refresh list
-    - `D`: Remove selected volume (with confirmation)
-    - `F`: Force remove selected volume (with confirmation)
-    - `Esc`/`q`: Back to Docker Compose process list
 
 11. **File Browser View**: Browse filesystem inside containers
-    - `↑`/`k`: Move up
-    - `↓`/`j`: Move down
-    - `Enter`: Open directory or view file
-    - `u`: Go to parent directory
-    - `r`: Refresh list
-    - `?`: Show help view
-    - `Esc`/`q`: Back to container list
 
 12. **File Content View**: View file contents from containers
-    - `↑`/`k`: Scroll up
-    - `↓`/`j`: Scroll down
-    - `G`: Jump to end
-    - `g`: Jump to start
-    - `?`: Show help view
-    - `Esc`/`q`: Back to file browser
 
 13. **Inspect View**: Shows full container configuration in JSON format
-    - `↑`/`k`: Scroll up
-    - `↓`/`j`: Scroll down
-    - `G`: Jump to end
-    - `g`: Jump to start
-    - `?`: Show help view
-    - `Esc`/`q`: Back to container list
 
 14. **Help View**: Displays all available keyboard shortcuts for the current view
-    - `↑`/`k`: Scroll up
-    - `↓`/`j`: Scroll down
-    - `Esc`/`q`: Back to previous view
 
 15. **Command Mode**: Vim-style command line interface
-    - `:q` or `:quit`: Quit with confirmation
-    - `:q!` or `:quit!`: Force quit without confirmation
-    - `:help commands`: List all available commands
-    - **Key handler commands**: All key handlers can be called as commands (e.g., `:ps`)
+    - All key handlers can be called as commands
+    - See [docs/keymap.md](docs/keymap.md#command-mode) for available commands
 
 16. **Command Execution View**: Shows real-time output of Docker commands
     - Displays the exact Docker command being executed
     - Shows confirmation dialog for aggressive operations (stop, start, kill, restart, delete, etc.)
     - Confirmation dialog shows: "Are you sure you want to execute: docker [command]"
-    - `y`: Confirm and execute the command
-    - `n` or `Esc`: Cancel and return to previous view
-    - `↑`/`k`: Scroll up through command output
-    - `↓`/`j`: Scroll down through command output
-    - `G`: Jump to end of output
-    - `g`: Jump to start of output
-    - `Ctrl+C`: Cancel running command
-    - `Esc`: Return to previous view (after command completes)
 
 ## Development Guidelines
 

--- a/README.md
+++ b/README.md
@@ -22,206 +22,85 @@ DCV is a TUI (Terminal User Interface) tool for monitoring Docker containers and
 
 ## Views
 
+For a complete list of keyboard shortcuts and commands, see [docs/keymap.md](docs/keymap.md).
+
 ### Docker Container List View
 
 Displays `docker ps` results in a table format. Shows all Docker containers, not limited to Docker Compose.
 
-**Key bindings:**
-- `↑`/`k`: Move up
-- `↓`/`j`: Move down
-- `Enter`: View container logs
-- `f`: Browse container files
-- `!`: Execute /bin/sh in container
-- `I`: Inspect container (view full config)
-- `a`: Toggle show all containers (including stopped)
-- `r`: Refresh list
-- `K`: Kill container
-- `S`: Stop container
-- `U`: Start container
-- `R`: Restart container
-- `P`: Pause/Unpause container
-- `D`: Delete stopped container
-- `?`: Show help view with all keybindings
-- `:`: Enter command mode (vim-style commands)
-- `q`/`Esc`: Back to Docker Compose process list
+For keyboard shortcuts, see [docs/keymap.md](docs/keymap.md#docker-container-list).
 
 ### Docker Compose Process List View
 
 Displays `docker compose ps` results in a table format.
 
-**Key bindings:**
-- `↑`/`k`: Move up
-- `↓`/`j`: Move down  
-- `Enter`: View container logs
-- `d`: View dind container contents (only for dind containers)
-- `f`: Browse container files
-- `!`: Execute /bin/sh in container
-- `I`: Inspect container (view full config)
-- `p`: Switch to Docker container list view
-- `i`: Switch to Docker image list view
-- `n`: Switch to Docker network list view
-- `P`: Switch to project list view
-- `V`: Switch to volume list view
-- `1`: Quick switch to Docker container list view
-- `2`: Quick switch to project list view
-- `3`: Quick switch to Docker image list view
-- `4`: Quick switch to Docker network list view
-- `5`: Quick switch to Docker volume list view
-- `a`: Toggle show all containers (including stopped)
-- `r`: Refresh list
-- `t`: Show process info (docker compose top)
-- `s`: Show container stats
-- `K`: Kill service
-- `S`: Stop service
-- `U`: Start service
-- `R`: Restart service
-- `P`: Pause/Unpause container
-- `D`: Delete stopped container
-- `u`: Deploy all services (docker compose up -d)
-- `x`: Stop and remove all services (docker compose down)
-- `?`: Show help view with all keybindings
-- `:`: Enter command mode (vim-style commands)
-- `q`: Quit (with confirmation)
+For keyboard shortcuts, see [docs/keymap.md](docs/keymap.md#docker-compose-process-list).
 
 ### Log View
 
 Displays container logs. Initially shows the last 1000 lines, then streams new logs in real-time.
 
-**Key bindings:**
-- `↑`/`k`: Scroll up
-- `↓`/`j`: Scroll down
-- `G`: Jump to end
-- `g`: Jump to start
-- `/`: Search logs (supports regex with Ctrl+R, case insensitive with Ctrl+I)
-- `f`: Filter logs (shows only lines matching the filter)
-- `n`: Next search result
-- `N`: Previous search result
-- `?`: Show help view
-- `Esc`/`q`: Back to previous view
+For keyboard shortcuts, see [docs/keymap.md](docs/keymap.md#log-view).
 
 ### Docker-in-Docker Process List View
 
 Shows containers running inside a dind container.
 
-**Key bindings:**
-- `↑`/`k`: Move up
-- `↓`/`j`: Move down
-- `Enter`: View container logs
-- `r`: Refresh list
-- `?`: Show help view
-- `Esc`/`q`: Back to process list
+For keyboard shortcuts, see [docs/keymap.md](docs/keymap.md#docker-in-docker).
 
 ### Image List View
 
 Displays Docker images with repository, tag, ID, creation time, and size information.
 
-**Key bindings:**
-- `↑`/`k`: Move up
-- `↓`/`j`: Move down
-- `I`: Inspect image (view full config)
-- `a`: Toggle show all images (including intermediate layers)
-- `r`: Refresh list
-- `D`: Remove selected image
-- `F`: Force remove selected image (even if used by containers)
-- `?`: Show help view
-- `Esc`/`q`: Back to Docker Compose process list
+For keyboard shortcuts, see [docs/keymap.md](docs/keymap.md#image-list).
 
 ### Network List View
 
 Displays Docker networks with ID, name, driver, scope, and container count.
 
-**Key bindings:**
-- `↑`/`k`: Move up
-- `↓`/`j`: Move down
-- `Enter`: Inspect network (view full config)
-- `r`: Refresh list
-- `D`: Remove selected network (except default networks)
-- `?`: Show help view
-- `Esc`/`q`: Back to Docker Compose process list
+For keyboard shortcuts, see [docs/keymap.md](docs/keymap.md#network-list).
 
 ### Volume List View
 
 Displays Docker volumes with name, driver, scope, size, creation time, and reference count.
 
-**Key bindings:**
-- `↑`/`k`: Move up
-- `↓`/`j`: Move down
-- `Enter`: Inspect volume (view full config)
-- `r`: Refresh list
-- `D`: Remove selected volume
-- `F`: Force remove selected volume (even if used by containers)
-- `?`: Show help view
-- `Esc`/`q`: Back to Docker Compose process list
+For keyboard shortcuts, see [docs/keymap.md](docs/keymap.md#volume-list).
 
 ### File Browser View
 
 Browse the filesystem inside a container. Navigate directories and view file contents.
 
-**Key bindings:**
-- `↑`/`k`: Move up
-- `↓`/`j`: Move down
-- `Enter`: Open directory or view file
-- `u`: Go to parent directory
-- `r`: Refresh list
-- `?`: Show help view
-- `Esc`/`q`: Back to container list
+For keyboard shortcuts, see [docs/keymap.md](docs/keymap.md#file-browser).
 
 ### File Content View
 
 View the contents of a file from within a container.
 
-**Key bindings:**
-- `↑`/`k`: Scroll up
-- `↓`/`j`: Scroll down
-- `G`: Jump to end
-- `g`: Jump to start
-- `?`: Show help view
-- `Esc`/`q`: Back to file browser
+For keyboard shortcuts, see [docs/keymap.md](docs/keymap.md#file-content).
 
 ### Inspect View
 
 Displays the full Docker inspect output for containers, images, or networks in JSON format with syntax highlighting.
 
-**Key bindings:**
-- `↑`/`k`: Scroll up
-- `↓`/`j`: Scroll down
-- `G`: Jump to end
-- `g`: Jump to start
-- `/`: Search
-- `n`: Next search result
-- `N`: Previous search result
-- `?`: Show help view
-- `Esc`/`q`: Back to previous view
+For keyboard shortcuts, see [docs/keymap.md](docs/keymap.md#inspect-view).
 
 ### Top View
 
 Shows process information (docker compose top) for the selected container.
 
-**Key bindings:**
-- `r`: Refresh
-- `?`: Show help view
-- `Esc`/`q`: Back to process list
+For keyboard shortcuts, see [docs/keymap.md](docs/keymap.md#top-view).
 
 ### Stats View
 
 Shows container resource usage statistics including CPU, memory, network I/O, and block I/O.
 
-**Key bindings:**
-- `r`: Refresh
-- `?`: Show help view
-- `Esc`/`q`: Back to process list
+For keyboard shortcuts, see [docs/keymap.md](docs/keymap.md#stats-view).
 
 ### Compose Project List View
 
 Shows all Docker Compose projects on the system.
 
-**Key bindings:**
-- `↑`/`k`: Move up
-- `↓`/`j`: Move down
-- `Enter`: Select project and view its containers
-- `r`: Refresh list
-- `?`: Show help view
-- `q`: Quit
+For keyboard shortcuts, see [docs/keymap.md](docs/keymap.md#project-list).
 
 ### Help View
 
@@ -232,10 +111,7 @@ The help view displays three columns:
 - **Command**: The vim-style command that can be used in command mode (e.g., ':down')
 - **Description**: What the action does
 
-**Key bindings:**
-- `↑`/`k`: Scroll up
-- `↓`/`j`: Scroll down
-- `Esc`/`q`: Back to previous view
+For keyboard shortcuts, see [docs/keymap.md](docs/keymap.md#help-view).
 
 ### Command Mode
 
@@ -247,29 +123,7 @@ Vim-style command line interface for executing commands.
 - `:h` or `:help`: Show help view
 - `:help commands`: List all available commands in current view
 
-**Key handler commands:**
-All key handler functions can be called as commands. Commands are automatically derived from the handler method names and use kebab-case naming. Examples include:
-- `:up`: Move selection up
-- `:down`: Move selection down
-- `:log`: View container logs
-- `:kill`: Kill selected container
-- `:stop`: Stop selected container
-- `:start`: Start selected container
-- `:restart`: Restart selected container
-- `:file-browse`: Browse container files
-- `:shell`: Execute /bin/sh in container
-- `:inspect`: Show inspect view
-- `:stats`: Show container stats
-- `:top`: Show process info
-
-For a complete list of available commands in each view, see [docs/keymap.md](docs/keymap.md) or use `:help commands` in command mode.
-
-**Key bindings:**
-- `:`: Enter command mode from any view
-- `↑`/`↓`: Navigate command history
-- `←`/`→`: Move cursor in command line
-- `Enter`: Execute command
-- `Esc`: Cancel command mode
+All key handler functions can be called as commands. For a complete list of available commands in each view, see [docs/keymap.md](docs/keymap.md#command-mode) or use `:help commands` in command mode.
 
 ## Usage
 
@@ -364,13 +218,7 @@ go build -o dcv
 
 Shows real-time output when executing Docker commands (start, stop, restart, kill, rm, docker compose up/down).
 
-**Key bindings:**
-- `↑`/`k`: Scroll up
-- `↓`/`j`: Scroll down
-- `G`: Jump to end
-- `g`: Jump to start
-- `Ctrl+C`: Cancel running command
-- `Esc`: Back to previous view
+For keyboard shortcuts, see [docs/keymap.md](docs/keymap.md#command-execution).
 
 ## Debugging Features
 

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Shows all available keyboard shortcuts and their corresponding commands for the 
 
 The help view displays three columns:
 - **Key**: The keyboard shortcut (e.g., 'j' or 'down')
-- **Command**: The vim-style command that can be used in command mode (e.g., ':cmd-down')
+- **Command**: The vim-style command that can be used in command mode (e.g., ':down')
 - **Description**: What the action does
 
 **Key bindings:**
@@ -248,36 +248,21 @@ Vim-style command line interface for executing commands.
 - `:help commands`: List all available commands in current view
 
 **Key handler commands:**
-All key handler functions can be called as commands. Commands are automatically derived from the handler method names and use either short forms or kebab-case naming:
-- `:up` or `:cmd-up`: Move selection up
-- `:down` or `:cmd-down`: Move selection down
-- `:log` or `:cmd-log`: View container logs
-- `:kill` or `:cmd-kill`: Kill selected container
-- `:stop` or `:cmd-stop`: Stop selected container
-- `:start` or `:cmd-start`: Start selected container
-- `:restart` or `:cmd-restart`: Restart selected container
-- `:filebrowse` or `:cmd-file-browse`: Browse container files
-- `:shell` or `:cmd-shell`: Execute /bin/sh in container
-- `:inspect` or `:cmd-inspect`: Show inspect view
-- `:stats` or `:cmd-stats`: Show container stats
-- `:top` or `:cmd-top`: Show process info
-- And many more...
+All key handler functions can be called as commands. Commands are automatically derived from the handler method names and use kebab-case naming. Examples include:
+- `:up`: Move selection up
+- `:down`: Move selection down
+- `:log`: View container logs
+- `:kill`: Kill selected container
+- `:stop`: Stop selected container
+- `:start`: Start selected container
+- `:restart`: Restart selected container
+- `:file-browse`: Browse container files
+- `:shell`: Execute /bin/sh in container
+- `:inspect`: Show inspect view
+- `:stats`: Show container stats
+- `:top`: Show process info
 
-**Command aliases:**
-- `:up` → Move selection up
-- `:down` → Move selection down
-- `:log` or `:logs` → View container logs
-- `:inspect` → Show inspect view
-- `:shell` or `:exec` → Execute shell in container
-- `:ps` → Show Docker container list
-- `:images` → Show image list
-- `:networks` → Show network list
-- `:volumes` → Show volume list
-- `:remove` or `:rm` → Remove/delete container
-- `:all` or `:a` → Toggle show all containers
-- `:refresh` or `:r` → Refresh current view
-- `:quit` or `:q` → Quit application
-- `:help` or `:h` → Show help
+For a complete list of available commands in each view, see [docs/keymap.md](docs/keymap.md) or use `:help commands` in command mode.
 
 **Key bindings:**
 - `:`: Enter command mode from any view


### PR DESCRIPTION
## Summary
- Removed detailed keyboard shortcut lists from README.md to avoid duplication
- Replaced with links to docs/keymap.md for better maintainability
- Added general reference to keymap documentation at the beginning of Views section

## Why this change?
Having keyboard shortcuts documented in multiple places (README.md and docs/keymap.md) creates maintenance overhead. Since docs/keymap.md is auto-generated from the actual code, it's always accurate. This change eliminates the need to manually update shortcuts in the README.

## Changes
- Removed all detailed key binding sections from each view description
- Added links to relevant sections in docs/keymap.md
- Simplified command mode documentation to reference the keymap file

This makes the documentation easier to maintain and ensures users always see accurate, up-to-date keyboard shortcuts.

🤖 Generated with [Claude Code](https://claude.ai/code)