### PR TITLE
fix: grant write permissions for screenshots workflow on main branch

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -17,7 +17,7 @@ jobs:
   generate:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
     
     steps:


### PR DESCRIPTION
## Summary
- Changed workflow permissions from `contents: read` to `contents: write` to allow pushing screenshot updates

## Problem
The screenshots workflow was failing on the main branch with a 403 permission error when trying to push commits. The workflow couldn't update screenshots after merging PRs.

## Solution
Updated the permissions in the workflow to grant write access to repository contents, enabling the workflow to commit and push screenshot updates when running on the main branch.

## Test plan
- [x] Workflow syntax is valid
- [x] Tests pass locally
- [ ] Workflow will be able to push to main branch after merge

🤖 Generated with [Claude Code](https://claude.ai/code)