### PR TITLE
feat: add mouse support for navbar navigation

### DIFF
--- a/internal/ui/mouse.go
+++ b/internal/ui/mouse.go
@@ -1,0 +1,120 @@
+package ui
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// NavbarItem represents a clickable item in the navbar
+type NavbarItem struct {
+	Label    string
+	ViewType ViewType
+	Key      string
+	StartX   int
+	EndX     int
+}
+
+// NavbarMouseZone tracks the clickable areas in the navbar
+type NavbarMouseZone struct {
+	Items      []NavbarItem
+	HideButton NavbarItem
+}
+
+// calculateNavbarZones calculates the clickable zones for the navbar
+func (m *Model) calculateNavbarZones() NavbarMouseZone {
+	zones := NavbarMouseZone{
+		Items: []NavbarItem{},
+	}
+
+	// Track current X position
+	currentX := 0
+
+	// Helper function to add nav item and track its position
+	addNavItem := func(key, label string, viewType ViewType) {
+		item := NavbarItem{
+			Label:    label,
+			ViewType: viewType,
+			Key:      key,
+			StartX:   currentX,
+		}
+		// Format: "[key] label"
+		itemText := "[" + key + "] " + label
+		itemWidth := lipgloss.Width(itemText)
+		item.EndX = currentX + itemWidth
+		zones.Items = append(zones.Items, item)
+
+		// Update position for next item (add separator width)
+		currentX = item.EndX + 3 // " | " separator
+	}
+
+	// Add navigation items in the same order as viewNavigationHeader
+	addNavItem("1", "Containers", DockerContainerListView)
+	addNavItem("2", "Projects", ComposeProjectListView)
+	addNavItem("3", "Images", ImageListView)
+	addNavItem("4", "Networks", NetworkListView)
+	addNavItem("5", "Volumes", VolumeListView)
+	addNavItem("6", "Stats", StatsView)
+
+	// Add hide navbar button
+	zones.HideButton = NavbarItem{
+		Label:  "[H]ide navbar",
+		StartX: currentX,
+		EndX:   currentX + lipgloss.Width("[H]ide navbar"),
+	}
+
+	return zones
+}
+
+// handleMouseClick handles mouse click events on the navbar
+func (m *Model) handleNavbarMouseClick(x, y int) (tea.Model, tea.Cmd) {
+	// Only handle clicks on the first line (navbar)
+	if y != 0 || m.navbarHidden {
+		return m, nil
+	}
+
+	zones := m.calculateNavbarZones()
+
+	// Check if click is on a navigation item
+	for _, item := range zones.Items {
+		if x >= item.StartX && x <= item.EndX {
+			// Switch to the clicked view
+			return m.handleNavigationKey(item.Key)
+		}
+	}
+
+	// Check if click is on hide button
+	if x >= zones.HideButton.StartX && x <= zones.HideButton.EndX {
+		m.navbarHidden = true
+		return m, nil
+	}
+
+	return m, nil
+}
+
+// handleNavigationKey handles keyboard navigation shortcuts
+func (m *Model) handleNavigationKey(key string) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	switch key {
+	case "1":
+		cmd = m.dockerContainerListViewModel.Show(m)
+	case "2":
+		cmd = m.composeProjectListViewModel.Show(m)
+	case "3":
+		cmd = m.imageListViewModel.Show(m)
+	case "4":
+		cmd = m.networkListViewModel.Show(m)
+	case "5":
+		cmd = m.volumeListViewModel.Show(m)
+	case "6":
+		cmd = m.statsViewModel.Show(m)
+	default:
+		return m, nil
+	}
+	return m, cmd
+}
+
+// isNavbarClick checks if a click is in the navbar area
+func isNavbarClick(msg tea.MouseMsg) bool {
+	// Navbar is on the first line (y=0) and only when left button is pressed
+	return msg.Y == 0 && msg.Action == tea.MouseActionPress && msg.Button == tea.MouseButtonLeft
+}

--- a/internal/ui/mouse_test.go
+++ b/internal/ui/mouse_test.go
@@ -1,0 +1,182 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCalculateNavbarZones(t *testing.T) {
+	m := NewModel(ComposeProcessListView)
+	zones := m.calculateNavbarZones()
+
+	// Check that we have the expected number of items
+	assert.Equal(t, 6, len(zones.Items))
+
+	// Check first item (Containers)
+	assert.Equal(t, "Containers", zones.Items[0].Label)
+	assert.Equal(t, DockerContainerListView, zones.Items[0].ViewType)
+	assert.Equal(t, "1", zones.Items[0].Key)
+	assert.Equal(t, 0, zones.Items[0].StartX)
+	assert.Greater(t, zones.Items[0].EndX, zones.Items[0].StartX)
+
+	// Check that items don't overlap
+	for i := 1; i < len(zones.Items); i++ {
+		assert.GreaterOrEqual(t, zones.Items[i].StartX, zones.Items[i-1].EndX+3) // +3 for separator
+	}
+
+	// Check hide button
+	assert.Equal(t, "[H]ide navbar", zones.HideButton.Label)
+	assert.Greater(t, zones.HideButton.EndX, zones.HideButton.StartX)
+}
+
+func TestHandleNavbarMouseClick(t *testing.T) {
+	tests := []struct {
+		name         string
+		x            int
+		y            int
+		navbarHidden bool
+		expectedView ViewType
+		shouldChange bool
+	}{
+		{
+			name:         "click on Containers",
+			x:            5, // Somewhere in "[1] Containers"
+			y:            0,
+			navbarHidden: false,
+			expectedView: DockerContainerListView,
+			shouldChange: true,
+		},
+		{
+			name:         "click below navbar",
+			x:            5,
+			y:            1,
+			navbarHidden: false,
+			expectedView: ComposeProcessListView,
+			shouldChange: false,
+		},
+		{
+			name:         "click when navbar hidden",
+			x:            5,
+			y:            0,
+			navbarHidden: true,
+			expectedView: ComposeProcessListView,
+			shouldChange: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewModel(ComposeProcessListView)
+			m.navbarHidden = tt.navbarHidden
+			m.initializeKeyHandlers()
+
+			model, _ := m.handleNavbarMouseClick(tt.x, tt.y)
+			resultModel := model.(*Model)
+
+			if tt.shouldChange {
+				assert.Equal(t, tt.expectedView, resultModel.currentView)
+			} else {
+				assert.Equal(t, ComposeProcessListView, resultModel.currentView)
+			}
+		})
+	}
+}
+
+func TestHandleNavigationKey(t *testing.T) {
+	tests := []struct {
+		key          string
+		expectedView ViewType
+	}{
+		{"1", DockerContainerListView},
+		{"2", ComposeProjectListView},
+		{"3", ImageListView},
+		{"4", NetworkListView},
+		{"5", VolumeListView},
+		{"6", StatsView},
+		{"invalid", ComposeProcessListView}, // Should not change
+	}
+
+	for _, tt := range tests {
+		t.Run("key_"+tt.key, func(t *testing.T) {
+			m := NewModel(ComposeProcessListView)
+			m.initializeKeyHandlers()
+
+			model, _ := m.handleNavigationKey(tt.key)
+			resultModel := model.(*Model)
+
+			if tt.key != "invalid" {
+				assert.Equal(t, tt.expectedView, resultModel.currentView)
+			} else {
+				assert.Equal(t, ComposeProcessListView, resultModel.currentView)
+			}
+		})
+	}
+}
+
+func TestIsNavbarClick(t *testing.T) {
+	tests := []struct {
+		name     string
+		msg      tea.MouseMsg
+		expected bool
+	}{
+		{
+			name: "left click on navbar",
+			msg: tea.MouseMsg{
+				X:      10,
+				Y:      0,
+				Action: tea.MouseActionPress,
+				Button: tea.MouseButtonLeft,
+			},
+			expected: true,
+		},
+		{
+			name: "left click below navbar",
+			msg: tea.MouseMsg{
+				X:      10,
+				Y:      1,
+				Action: tea.MouseActionPress,
+				Button: tea.MouseButtonLeft,
+			},
+			expected: false,
+		},
+		{
+			name: "right click on navbar",
+			msg: tea.MouseMsg{
+				X:      10,
+				Y:      0,
+				Action: tea.MouseActionPress,
+				Button: tea.MouseButtonRight,
+			},
+			expected: false,
+		},
+		{
+			name: "mouse motion on navbar",
+			msg: tea.MouseMsg{
+				X:      10,
+				Y:      0,
+				Action: tea.MouseActionMotion,
+				Button: tea.MouseButtonNone,
+			},
+			expected: false,
+		},
+		{
+			name: "mouse release on navbar",
+			msg: tea.MouseMsg{
+				X:      10,
+				Y:      0,
+				Action: tea.MouseActionRelease,
+				Button: tea.MouseButtonLeft,
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isNavbarClick(tt.msg)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -19,6 +19,14 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		return m.handleKeyPress(msg)
 
+	case tea.MouseMsg:
+		// Handle mouse events
+		if isNavbarClick(msg) {
+			return m.handleNavbarMouseClick(msg.X, msg.Y)
+		}
+		// TODO: Add more mouse handlers for other views
+		return m, nil
+
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.Height = msg.Height

--- a/main.go
+++ b/main.go
@@ -52,8 +52,8 @@ func main() {
 	// Create the initial model with configured view
 	m := ui.NewModel(initialView)
 
-	// Create the program
-	p := tea.NewProgram(m, tea.WithAltScreen())
+	// Create the program with mouse support
+	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
 
 	// Run the program
 	if _, err := p.Run(); err != nil {


### PR DESCRIPTION
## Summary
- Added mouse click support for the global navbar
- Users can now click on navigation items to switch between views
- Click support for the hide navbar button

## Features
✨ **Mouse Navigation**: Click on any navbar item ([1] Containers, [2] Projects, etc.) to instantly switch views
✨ **Hide Button**: Click on [H]ide navbar to hide the navigation bar
✨ **Proper Event Handling**: Only responds to left mouse button press events

## Implementation Details
- Created `mouse.go` with navbar click zone calculation
- Added mouse event handling in the Update function
- Enabled mouse support with `tea.WithMouseCellMotion()` in main
- Comprehensive test coverage for all mouse interactions

## Testing
- Added tests for click zone calculation
- Added tests for mouse event handling
- All existing tests pass
- Linter checks pass

This is the first step in adding full mouse support to the TUI. Future PRs can extend mouse support to:
- Container list selection
- Scrolling in log views
- Button interactions in dialogs

🤖 Generated with [Claude Code](https://claude.ai/code)