### PR TITLE
feat: add Deploy action for running Docker Compose projects

### DIFF
--- a/internal/ui/view_compose_project_action.go
+++ b/internal/ui/view_compose_project_action.go
@@ -48,6 +48,17 @@ func (m *ComposeProjectActionViewModel) Initialize(project *models.ComposeProjec
 	// Project status dependent actions
 	if strings.Contains(project.Status, "running") {
 		m.actions = append(m.actions, ComposeProjectAction{
+			Key:         "U",
+			Name:        "Deploy",
+			Description: "Update containers (up -d)",
+			Aggressive:  false,
+			Handler: func(model *Model, p models.ComposeProject) tea.Cmd {
+				args := []string{"compose", "-p", p.Name, "up", "-d"}
+				return model.commandExecutionViewModel.ExecuteCommand(model, false, args...)
+			},
+		})
+
+		m.actions = append(m.actions, ComposeProjectAction{
 			Key:         "D",
 			Name:        "Down",
 			Description: "Stop and remove containers, networks",

--- a/internal/ui/view_compose_project_action_test.go
+++ b/internal/ui/view_compose_project_action_test.go
@@ -17,10 +17,10 @@ func TestComposeProjectActionViewModel_Initialize(t *testing.T) {
 		unexpectedKeys []string
 	}{
 		{
-			name:           "running project shows down/stop/restart actions",
+			name:           "running project shows deploy/down/stop/restart actions",
 			projectStatus:  "running(2)",
-			expectedKeys:   []string{"D", "S", "R"},
-			unexpectedKeys: []string{"U"},
+			expectedKeys:   []string{"U", "D", "S", "R"},
+			unexpectedKeys: []string{},
 		},
 		{
 			name:           "stopped project shows up/start actions",


### PR DESCRIPTION
## Summary
Add 'Deploy' action (docker compose up -d) for running projects to allow updating containers with new images or configuration changes.

## Changes
- Add Deploy action with 'U' key for running projects (executes `docker compose up -d`)
- Non-aggressive operation (no confirmation required)
- Complements existing Down, Stop, and Restart actions

## Use Case
This is useful for rolling out updates without taking down the entire stack. When you have a running project and want to update containers with:
- New Docker images that have been pulled
- Configuration changes in docker-compose.yml
- Environment variable updates

The Deploy action will recreate only the containers that need updating while keeping others running.

## Test Plan
- [x] Unit tests pass for ComposeProjectActionViewModel
- [x] Deploy action appears for running projects
- [x] Deploy action doesn't appear for stopped projects
- [ ] Manual testing with real Docker Compose projects