### PR TITLE
refactor: migrate ComposeProjectListViewModel to use TableViewModel

### DIFF
--- a/internal/ui/table_model.go
+++ b/internal/ui/table_model.go
@@ -107,37 +107,37 @@ func clamp(v, low, high int) int {
 	return min(max(v, low), high)
 }
 
-// HandleUp moves selection up in the image list
-func (m *ImageListViewModel) HandleUp(model *Model) tea.Cmd {
+// HandleUp moves selection up in the table
+func (t *TableViewModel) HandleUp(model *Model) tea.Cmd {
 	height := model.ViewHeight()
 	if height <= 0 {
 		height = 10 // fallback
 	}
-	if m.Cursor > 0 {
-		m.Cursor--
-		if m.Cursor < m.Start {
-			m.Start = m.Cursor
+	if t.Cursor > 0 {
+		t.Cursor--
+		if t.Cursor < t.Start {
+			t.Start = t.Cursor
 		}
-		m.End = clamp(m.Start+height, 0, len(m.Rows))
+		t.End = clamp(t.Start+height, 0, len(t.Rows))
 	}
 	return nil
 }
 
-// HandleDown moves selection down in the image list
-func (m *ImageListViewModel) HandleDown(model *Model) tea.Cmd {
+// HandleDown moves selection down in the table
+func (t *TableViewModel) HandleDown(model *Model) tea.Cmd {
 	height := model.ViewHeight()
 	if height <= 0 {
 		height = 10 // fallback
 	}
-	if m.Cursor < len(m.Rows)-1 {
-		m.Cursor++
-		if m.Cursor >= m.End {
-			m.Start = m.Cursor - height + 1
-			if m.Start < 0 {
-				m.Start = 0
+	if t.Cursor < len(t.Rows)-1 {
+		t.Cursor++
+		if t.Cursor >= t.End {
+			t.Start = t.Cursor - height + 1
+			if t.Start < 0 {
+				t.Start = 0
 			}
 		}
-		m.End = clamp(m.Start+height, 0, len(m.Rows))
+		t.End = clamp(t.Start+height, 0, len(t.Rows))
 	}
 	return nil
 }

--- a/internal/ui/view_compose_project_list.go
+++ b/internal/ui/view_compose_project_list.go
@@ -90,39 +90,6 @@ func (m *ComposeProjectListViewModel) render(model *Model, availableHeight int) 
 	})
 }
 
-func (m *ComposeProjectListViewModel) HandleUp(model *Model) tea.Cmd {
-	height := model.ViewHeight()
-	if height <= 0 {
-		height = 10 // fallback
-	}
-	if m.Cursor > 0 {
-		m.Cursor--
-		if m.Cursor < m.Start {
-			m.Start = m.Cursor
-		}
-		m.End = clamp(m.Start+height, 0, len(m.Rows))
-	}
-	return nil
-}
-
-func (m *ComposeProjectListViewModel) HandleDown(model *Model) tea.Cmd {
-	height := model.ViewHeight()
-	if height <= 0 {
-		height = 10 // fallback
-	}
-	if m.Cursor < len(m.Rows)-1 {
-		m.Cursor++
-		if m.Cursor >= m.End {
-			m.Start = m.Cursor - height + 1
-			if m.Start < 0 {
-				m.Start = 0
-			}
-		}
-		m.End = clamp(m.Start+height, 0, len(m.Rows))
-	}
-	return nil
-}
-
 func (m *ComposeProjectListViewModel) HandleSelectProject(model *Model) tea.Cmd {
 	if m.Cursor < len(m.projects) {
 		project := m.projects[m.Cursor]

--- a/internal/ui/view_compose_project_list_test.go
+++ b/internal/ui/view_compose_project_list_test.go
@@ -18,10 +18,8 @@ func TestComposeProjectListViewModel_Rendering(t *testing.T) {
 		{
 			name: "displays no projects message when empty",
 			viewModel: ComposeProjectListViewModel{
-				TableViewModel: TableViewModel{
-					Cursor: 0,
-				},
-				projects: []models.ComposeProject{},
+				TableViewModel: TableViewModel{Cursor: 0},
+				projects:       []models.ComposeProject{},
 			},
 			height:   20,
 			expected: []string{"No Docker Compose projects found"},
@@ -41,9 +39,7 @@ func TestComposeProjectListViewModel_Rendering(t *testing.T) {
 						ConfigFiles: "/home/user/database/docker-compose.yml",
 					},
 				},
-				TableViewModel: TableViewModel{
-					Cursor: 0,
-				},
+				TableViewModel: TableViewModel{Cursor: 0},
 			},
 			height: 20,
 			expected: []string{
@@ -69,9 +65,7 @@ func TestComposeProjectListViewModel_Rendering(t *testing.T) {
 						Status: "exited",
 					},
 				},
-				TableViewModel: TableViewModel{
-					Cursor: 0,
-				},
+				TableViewModel: TableViewModel{Cursor: 0},
 			},
 			height:   20,
 			expected: []string{"running-project", "exited-project"},
@@ -86,9 +80,7 @@ func TestComposeProjectListViewModel_Rendering(t *testing.T) {
 						ConfigFiles: "/very/long/path/that/should/be/truncated/in/the/display/docker-compose.yml",
 					},
 				},
-				TableViewModel: TableViewModel{
-					Cursor: 0,
-				},
+				TableViewModel: TableViewModel{Cursor: 0},
 			},
 			height:   20,
 			expected: []string{"/very/long/path/that/should/be/truncated/in/the..."},
@@ -103,8 +95,10 @@ func TestComposeProjectListViewModel_Rendering(t *testing.T) {
 				Height:                      tt.height,
 			}
 
-			// Initialize table rows
-			tt.viewModel.SetRows(tt.viewModel.buildRows(), model.ViewHeight())
+			// Initialize table rows if projects exist
+			if len(tt.viewModel.projects) > 0 {
+				tt.viewModel.SetRows(tt.viewModel.buildRows(), model.ViewHeight())
+			}
 
 			result := tt.viewModel.render(model, tt.height-4)
 
@@ -123,9 +117,6 @@ func TestComposeProjectListViewModel_Navigation(t *testing.T) {
 				{Name: "project1"},
 				{Name: "project2"},
 				{Name: "project3"},
-			},
-			TableViewModel: TableViewModel{
-				Cursor: 0,
 			},
 		}
 		vm.SetRows(vm.buildRows(), model.ViewHeight())
@@ -149,11 +140,9 @@ func TestComposeProjectListViewModel_Navigation(t *testing.T) {
 				{Name: "project2"},
 				{Name: "project3"},
 			},
-			TableViewModel: TableViewModel{
-				Cursor: 2,
-			},
 		}
 		vm.SetRows(vm.buildRows(), model.ViewHeight())
+		vm.Cursor = 2
 
 		cmd := vm.HandleUp(model)
 		assert.Nil(t, cmd)
@@ -177,9 +166,7 @@ func TestComposeProjectListViewModel_Operations(t *testing.T) {
 			projects: []models.ComposeProject{
 				{Name: "my-project"},
 			},
-			TableViewModel: TableViewModel{
-				Cursor: 0,
-			},
+			TableViewModel: TableViewModel{Cursor: 0},
 		}
 		model.composeProjectListViewModel = *vm
 
@@ -195,10 +182,8 @@ func TestComposeProjectListViewModel_Operations(t *testing.T) {
 		}
 		model.composeProcessListViewModel.projectName = "old-project"
 		vm := &ComposeProjectListViewModel{
-			projects: []models.ComposeProject{},
-			TableViewModel: TableViewModel{
-				Cursor: 0,
-			},
+			projects:       []models.ComposeProject{},
+			TableViewModel: TableViewModel{Cursor: 0},
 		}
 
 		cmd := vm.HandleSelectProject(model)
@@ -214,9 +199,7 @@ func TestComposeProjectListViewModel_Operations(t *testing.T) {
 			projects: []models.ComposeProject{
 				{Name: "project1"},
 			},
-			TableViewModel: TableViewModel{
-				Cursor: 5,
-			}, // Out of bounds
+			TableViewModel: TableViewModel{Cursor: 5}, // Out of bounds
 		}
 
 		cmd := vm.HandleSelectProject(model)
@@ -228,9 +211,7 @@ func TestComposeProjectListViewModel_Operations(t *testing.T) {
 func TestComposeProjectListViewModel_Messages(t *testing.T) {
 	t.Run("Loaded updates project list", func(t *testing.T) {
 		vm := &ComposeProjectListViewModel{
-			TableViewModel: TableViewModel{
-				Cursor: 5, // Out of bounds
-			},
+			TableViewModel: TableViewModel{Cursor: 5}, // Out of bounds
 		}
 
 		projects := []models.ComposeProject{
@@ -247,9 +228,7 @@ func TestComposeProjectListViewModel_Messages(t *testing.T) {
 
 	t.Run("Loaded keeps selection in bounds", func(t *testing.T) {
 		vm := &ComposeProjectListViewModel{
-			TableViewModel: TableViewModel{
-				Cursor: 1,
-			},
+			TableViewModel: TableViewModel{Cursor: 1},
 		}
 
 		projects := []models.ComposeProject{
@@ -269,10 +248,8 @@ func TestComposeProjectListViewModel_EmptySelection(t *testing.T) {
 	t.Run("operations handle empty project list gracefully", func(t *testing.T) {
 		model := &Model{}
 		vm := &ComposeProjectListViewModel{
-			projects: []models.ComposeProject{},
-			TableViewModel: TableViewModel{
-				Cursor: 0,
-			},
+			projects:       []models.ComposeProject{},
+			TableViewModel: TableViewModel{Cursor: 0},
 		}
 
 		// Test operations that depend on selection

--- a/internal/ui/view_docker_container_list.go
+++ b/internal/ui/view_docker_container_list.go
@@ -182,39 +182,6 @@ func (m *DockerContainerListViewModel) renderDockerList(model *Model, availableH
 	})
 }
 
-func (m *DockerContainerListViewModel) HandleUp(model *Model) tea.Cmd {
-	height := model.ViewHeight()
-	if height <= 0 {
-		height = 10 // fallback
-	}
-	if m.Cursor > 0 {
-		m.Cursor--
-		if m.Cursor < m.Start {
-			m.Start = m.Cursor
-		}
-		m.End = clamp(m.Start+height, 0, len(m.Rows))
-	}
-	return nil
-}
-
-func (m *DockerContainerListViewModel) HandleDown(model *Model) tea.Cmd {
-	height := model.ViewHeight()
-	if height <= 0 {
-		height = 10 // fallback
-	}
-	if m.Cursor < len(m.Rows)-1 {
-		m.Cursor++
-		if m.Cursor >= m.End {
-			m.Start = m.Cursor - height + 1
-			if m.Start < 0 {
-				m.Start = 0
-			}
-		}
-		m.End = clamp(m.Start+height, 0, len(m.Rows))
-	}
-	return nil
-}
-
 func (m *DockerContainerListViewModel) GetContainer(model *Model) *docker.Container {
 	// Get the selected Docker container
 	if m.Cursor < len(m.dockerContainers) {


### PR DESCRIPTION
## Summary
- Migrate ComposeProjectListViewModel to embed and use TableViewModel for consistent table handling
- Move HandleUp/HandleDown methods to TableViewModel base struct to eliminate code duplication
- Update all references from selectedProject field to unified Cursor field

## Changes
- Embed TableViewModel in ComposeProjectListViewModel
- Remove duplicate HandleUp/HandleDown implementations from all view models
- Move HandleUp/HandleDown to TableViewModel where they belong
- Update tests to properly initialize table rows
- Update keyhandler references to use Cursor field instead of selectedProject

## Benefits
- Reduces code duplication across all list views
- Ensures consistent navigation behavior throughout the application
- Makes future maintenance easier with centralized table handling logic
- Completes the migration of all list views to the shared TableViewModel pattern

## Test Plan
- [x] All unit tests pass
- [x] Manual testing of compose project list navigation
- [x] Screenshots generated successfully
- [x] Navigation works correctly in all list views

🤖 Generated with [Claude Code](https://claude.ai/code)