### PR TITLE
cleanup: remove unused RenderTable function from table.go

### DIFF
--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -5,35 +5,6 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-func RenderTable(columns []table.Column, rows []table.Row, availableHeight int, selectedRow int) string {
-	t := table.New(
-		table.WithColumns(columns),
-		table.WithRows(rows),
-		table.WithFocused(true),
-		table.WithHeight(availableHeight-3),
-	)
-
-	// Set styles
-	tableStyle := table.DefaultStyles()
-	tableStyle.Header = tableStyle.Header.
-		BorderStyle(lipgloss.NormalBorder()).
-		BorderForeground(lipgloss.Color("240")).
-		BorderBottom(true).
-		Bold(false)
-	tableStyle.Selected = tableStyle.Selected.
-		Foreground(lipgloss.Color("229")).
-		Background(lipgloss.Color("57")).
-		Bold(false)
-
-	t.SetStyles(tableStyle)
-	t.Focus()
-
-	// Move to the selected row
-	t.MoveDown(selectedRow)
-
-	return t.View()
-}
-
 // RenderUnfocusedTable renders a table without selection/focus capability
 func RenderUnfocusedTable(columns []table.Column, rows []table.Row, availableHeight int) string {
 	t := table.New(


### PR DESCRIPTION
## Summary
- Remove unused standalone `RenderTable` function from `table.go`
- All views have been refactored to use `TableViewModel`'s `RenderTable` method
- Keep `RenderUnfocusedTable` as it's still used for non-interactive table rendering

## Context
This is a cleanup following the complete TableViewModel refactoring. The standalone `RenderTable` function is no longer needed since all list views now embed `TableViewModel` and use its `RenderTable` method instead.

## Test plan
- [x] All tests pass
- [x] Code properly formatted and linted
- [x] Screenshots generate correctly
- [x] No functionality changes - pure cleanup

🤖 Generated with [Claude Code](https://claude.ai/code)