### PR TITLE
feat: implement inspect view for volumes, networks, and images in tview UI

### DIFF
--- a/internal/tui/views/image_list.go
+++ b/internal/tui/views/image_list.go
@@ -15,11 +15,12 @@ import (
 
 // ImageListView displays Docker images
 type ImageListView struct {
-	docker       *docker.Client
-	table        *tview.Table
-	dockerImages []models.DockerImage
-	showAll      bool
-	pages        *tview.Pages
+	docker                *docker.Client
+	table                 *tview.Table
+	dockerImages          []models.DockerImage
+	showAll               bool
+	pages                 *tview.Pages
+	switchToInspectViewFn func(targetID string, target interface{})
 }
 
 // NewImageListView creates a new image list view
@@ -126,8 +127,11 @@ func (v *ImageListView) setupKeyHandlers() {
 			// Inspect image
 			if row > 0 && row <= len(v.dockerImages) {
 				image := v.dockerImages[row-1]
-				// TODO: Switch to inspect view
-				slog.Info("Inspect image", slog.String("image", image.GetRepoTag()))
+				if v.switchToInspectViewFn != nil {
+					v.switchToInspectViewFn(image.ID, image)
+				} else {
+					slog.Info("Inspect image", slog.String("image", image.GetRepoTag()))
+				}
 			}
 			return nil
 
@@ -191,6 +195,11 @@ func (v *ImageListView) GetTitle() string {
 		return "Docker Images (all)"
 	}
 	return "Docker Images"
+}
+
+// SetSwitchToInspectViewCallback sets the callback for switching to inspect view
+func (v *ImageListView) SetSwitchToInspectViewCallback(fn func(targetID string, target interface{})) {
+	v.switchToInspectViewFn = fn
 }
 
 // loadImages loads the image list from Docker

--- a/internal/tui/views/network_list.go
+++ b/internal/tui/views/network_list.go
@@ -15,10 +15,11 @@ import (
 
 // NetworkListView displays Docker networks
 type NetworkListView struct {
-	docker         *docker.Client
-	table          *tview.Table
-	dockerNetworks []models.DockerNetwork
-	pages          *tview.Pages
+	docker                *docker.Client
+	table                 *tview.Table
+	dockerNetworks        []models.DockerNetwork
+	pages                 *tview.Pages
+	switchToInspectViewFn func(targetID string, target interface{})
 }
 
 // NewNetworkListView creates a new network list view
@@ -99,8 +100,11 @@ func (v *NetworkListView) setupKeyHandlers() {
 			// Inspect network
 			if row > 0 && row <= len(v.dockerNetworks) {
 				network := v.dockerNetworks[row-1]
-				// TODO: Switch to inspect view
-				slog.Info("Inspect network", slog.String("network", network.Name))
+				if v.switchToInspectViewFn != nil {
+					v.switchToInspectViewFn(network.Name, network)
+				} else {
+					slog.Info("Inspect network", slog.String("network", network.Name))
+				}
 			}
 			return nil
 
@@ -158,6 +162,11 @@ func (v *NetworkListView) Refresh() {
 // GetTitle returns the title of the view
 func (v *NetworkListView) GetTitle() string {
 	return "Docker Networks"
+}
+
+// SetSwitchToInspectViewCallback sets the callback for switching to inspect view
+func (v *NetworkListView) SetSwitchToInspectViewCallback(fn func(targetID string, target interface{})) {
+	v.switchToInspectViewFn = fn
 }
 
 // loadNetworks loads the network list from Docker

--- a/internal/tui/views/volume_list.go
+++ b/internal/tui/views/volume_list.go
@@ -15,10 +15,11 @@ import (
 
 // VolumeListView displays Docker volumes
 type VolumeListView struct {
-	docker        *docker.Client
-	table         *tview.Table
-	dockerVolumes []models.DockerVolume
-	pages         *tview.Pages
+	docker                *docker.Client
+	table                 *tview.Table
+	dockerVolumes         []models.DockerVolume
+	pages                 *tview.Pages
+	switchToInspectViewFn func(targetID string, target interface{})
 }
 
 // NewVolumeListView creates a new volume list view
@@ -117,8 +118,11 @@ func (v *VolumeListView) setupKeyHandlers() {
 			// Inspect volume
 			if row > 0 && row <= len(v.dockerVolumes) {
 				volume := v.dockerVolumes[row-1]
-				// TODO: Switch to inspect view
-				slog.Info("Inspect volume", slog.String("volume", volume.Name))
+				if v.switchToInspectViewFn != nil {
+					v.switchToInspectViewFn(volume.Name, volume)
+				} else {
+					slog.Info("Inspect volume", slog.String("volume", volume.Name))
+				}
 			}
 			return nil
 
@@ -171,6 +175,11 @@ func (v *VolumeListView) Refresh() {
 // GetTitle returns the title of the view
 func (v *VolumeListView) GetTitle() string {
 	return "Docker Volumes"
+}
+
+// SetSwitchToInspectViewCallback sets the callback for switching to inspect view
+func (v *VolumeListView) SetSwitchToInspectViewCallback(fn func(targetID string, target interface{})) {
+	v.switchToInspectViewFn = fn
 }
 
 // loadVolumes loads the volume list from Docker


### PR DESCRIPTION
## Summary
- Extended inspect view functionality beyond containers to support volumes, networks, and images
- Added inspect view callbacks to VolumeListView, NetworkListView, and ImageListView
- Updated SwitchToInspectView to handle different Docker resource types

## Test plan
- [x] All tests pass (`make test`)
- [x] Code formatted with `make fmt`
- [ ] Press 'i' key in volume list view to inspect a volume
- [ ] Press 'i' key in network list view to inspect a network  
- [ ] Press 'i' key in image list view to inspect an image
- [ ] Verify inspect view displays correct YAML-formatted data for each resource type

🤖 Generated with [Claude Code](https://claude.ai/code)