### PR TITLE
feat: Add winget support for Windows package management

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,3 +34,4 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+        WINGET_GITHUB_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -61,3 +61,37 @@ brews:
       system "#{bin}/dcv", "--version"
     install: |
       bin.install "dcv"
+
+winget:
+  - name: tokuhirom.dcv
+    publisher: tokuhirom
+    short_description: "Docker Compose Viewer - A TUI tool for monitoring Docker containers"
+    description: |
+      DCV (Docker Container Viewer) is a TUI tool for monitoring Docker containers and Docker Compose applications.
+      It provides an interactive interface to manage containers, images, networks, and volumes with vim-like navigation.
+    license: MIT
+    publisher_url: https://github.com/tokuhirom
+    publisher_support_url: https://github.com/tokuhirom/dcv/issues
+    homepage: https://github.com/tokuhirom/dcv
+    license_url: https://github.com/tokuhirom/dcv/blob/main/LICENSE
+    copyright: Copyright (c) 2025 Tokuhiro Matsuno
+    tags:
+      - docker
+      - docker-compose
+      - tui
+      - container
+      - monitoring
+      - devops
+      - cli
+    repository:
+      owner: microsoft
+      name: winget-pkgs
+      branch: master
+      token: "{{ .Env.WINGET_GITHUB_TOKEN }}"
+      pull_request:
+        enabled: true
+        draft: false
+        base:
+          owner: microsoft
+          name: winget-pkgs
+          branch: master


### PR DESCRIPTION
## Summary
- Add winget configuration to .goreleaser.yml with cross-repository PR support
- Configure automatic PR creation to microsoft/winget-pkgs repository on releases
- Add WINGET_GITHUB_TOKEN to GitHub Actions workflow

## Details
This PR adds Windows Package Manager (winget) support to the project's release process. When a new release is tagged, goreleaser will automatically create a pull request to the official winget-pkgs repository, making the application available for Windows users through winget.

### Changes:
- **`.goreleaser.yml`**: Added winget configuration section with metadata and cross-repository PR settings
- **`.github/workflows/release.yml`**: Added WINGET_GITHUB_TOKEN environment variable for authentication

### Configuration Requirements:
- Requires `WINGET_GITHUB_TOKEN` secret to be configured in GitHub repository settings
- This token needs permissions to create pull requests to microsoft/winget-pkgs

## Test plan
- [x] Verify goreleaser configuration is valid
- [x] Run tests and linting
- [ ] Test release process with winget PR creation (will be tested on next release)